### PR TITLE
The Visual Studio 2013 Installer Projects extension is required to build the Setup project

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Il middleware qui presente è in fase di sviluppo, ed è da considerarsi in **ve
 Il middleware CIE è una libreria software che implementa le interfacce crittografiche standard **PKCS#11** e **CSP**. Esso consente agli applicativi integranti di utilizzare il certificato di autenticazione e la relativa chiave privata memorizzati sul chip della CIE astraendo dalle modalità di comunicazione di basso livello. 
 
 ## ARCHITETTURA
-La libreria è sviluppata in C++ su Visual Studio 2013. Allo stato attuale è utilizzabile esclusivamente in ambiente Windows. Entrambe le interfacce sono esposte della stessa libreria (CIEPKI.dll), che viene compilata dal progetto CSP. La libreria viene compilata sia in versione a 32 bit che a 64 bit.
+La libreria è sviluppata in C++ su Visual Studio 2013; per compilare il modulo di installazione (progetto **Setup**) è inoltre necessaria [l'estensione Visual Studio 2013 Installer Projects](https://marketplace.visualstudio.com/items?itemName=UnniRavindranathan-MSFT.MicrosoftVisualStudio2013InstallerProjects). Allo stato attuale è utilizzabile esclusivamente in ambiente Windows. Entrambe le interfacce sono esposte della stessa libreria (CIEPKI.dll), che viene compilata dal progetto CSP. La libreria viene compilata sia in versione a 32 bit che a 64 bit.
 Il progetto CSP ha un’unica dipendenza esterna: **OpenSSL**, versione **1.0.2k (LTS)**, a 32 e 64 bit. La libreria viene linkata staticamente, quindi non è necessaria la presenza delle librerie a runtime.
 
 L’interfaccia CSP è conforme alla versione 7 delle specifiche dei Minidriver pubblicate da Microsoft a [questo](http://download.microsoft.com/download/7/E/7/7E7662CF-CBEA-470B-A97E-CE7CE0D98DC2/sc-minidriver_specs_V7.docx) indirizzo.
@@ -23,5 +23,5 @@ Il modulo CSP implementa anche uno store provider per i certificati, in modo tal
 Allo stesso modo del CSP, anche il PKCS11 gestisce la carta in modalità **read-only**. Pertanto le operazioni di creazione, modifica e distruzione di qualsiasi oggetto restituiranno un errore.
 
 ## Setup
-Il modulo di installazione del Middleware si compila tramite il progetto **Setup**. Il setup installa sia la versione a 32 che a 64 bit, ed effettua la registrazione del CSP e dello Store provider. Il modulo PKCS11 non richiede registrazione, ma il nome del modulo (**CIEPKI.dll**) deve essere noto alle applicazioni che lo utilizzano.
+Il modulo di installazione del Middleware si compila tramite il progetto **Setup**, che richiede l'installazione dell'estensione [Visual Studio 2013 Installer Projects](https://marketplace.visualstudio.com/items?itemName=UnniRavindranathan-MSFT.MicrosoftVisualStudio2013InstallerProjects). Il setup installa sia la versione a 32 che a 64 bit, ed effettua la registrazione del CSP e dello Store provider. Il modulo PKCS11 non richiede registrazione, ma il nome del modulo (**CIEPKI.dll**) deve essere noto alle applicazioni che lo utilizzano.
 


### PR DESCRIPTION
Updated the README to note this, and added a link to the Visual Studio Marketplace page for the extension