### PR TITLE
Safe narrowing conversions

### DIFF
--- a/CSP/CSP/IAS.cpp
+++ b/CSP/CSP/IAS.cpp
@@ -146,7 +146,7 @@ void IAS::readfile(WORD id, ByteDynArray &content){
 
 	ByteDynArray resp;
 	BYTE selectFile[] = { 0x00, 0xa4, 0x02, 0x04 };
-	BYTE fileId[] = { id >> 8, id & 0xff };
+	BYTE fileId[] = { HIBYTE(id), LOBYTE(id) };
 	CARD_R_CALL(SendAPDU(VarToByteArray(selectFile), VarToByteArray(fileId), resp))
 
 
@@ -182,7 +182,7 @@ void IAS::readfile_SM(WORD id, ByteDynArray &content) {
 
 	ByteDynArray resp;
 	BYTE selectFile[] = { 0x00, 0xa4, 0x02, 0x04 };
-	BYTE fileId[] = { id >> 8, id & 0xff };
+	BYTE fileId[] = { HIBYTE(id), LOBYTE(id) };
 	CARD_R_CALL(SendAPDU_SM(VarToByteArray(selectFile), VarToByteArray(fileId), resp))
 
 

--- a/CSP/CSP/IAS.cpp
+++ b/CSP/CSP/IAS.cpp
@@ -12,6 +12,7 @@
 #include "../util/ModuleInfo.h"
 #include "../res/resource.h"
 #include "../../cacheLib/cacheLib.h"
+#include <intsafe.h>
 
 #define CIE_KEY_DH_ID 0x81
 #define CIE_KEY_ExtAuth_ID 0x84
@@ -163,7 +164,9 @@ void IAS::readfile(WORD id, ByteDynArray &content){
 		}
 		if (sw == 0x9000) {
 			content.append(chn);
-			cnt += chn.size();
+			WORD chnSize;
+			if (FAILED(SizeTToWord(chn.size(), &chnSize)) || FAILED(WordAdd(cnt, chnSize, &cnt)))
+				throw CStringException("File troppo grande");
 			chunk = 128;
 		}
 		else {
@@ -199,7 +202,9 @@ void IAS::readfile_SM(WORD id, ByteDynArray &content) {
 		}
 		if (sw == 0x9000) {
 			content.append(chn);
-			cnt += chn.size();
+			WORD chnSize;
+			if (FAILED(SizeTToWord(chn.size(), &chnSize)) || FAILED(WordAdd(cnt, chnSize, &cnt)))
+				throw CStringException("File troppo grande");
 			chunk = 128;
 		}
 		else {

--- a/CSP/CSP/IAS.cpp
+++ b/CSP/CSP/IAS.cpp
@@ -150,12 +150,12 @@ void IAS::readfile(WORD id, ByteDynArray &content){
 	CARD_R_CALL(SendAPDU(VarToByteArray(selectFile), VarToByteArray(fileId), resp))
 
 
-	int cnt = 0;
+	WORD cnt = 0;
 	BYTE chunk = 128;
 	DWORD sw;
 	while (true) {
 		ByteDynArray chn;
-		BYTE readFile[] = { 0x00, 0xb0, cnt >> 8, cnt & 0xff };
+		BYTE readFile[] = { 0x00, 0xb0, HIBYTE(cnt), LOBYTE(cnt) };
 		sw = SendAPDU(VarToByteArray(readFile), ByteArray(), chn, &chunk);
 		if ((sw >> 8) == 0x6c)  {
 			BYTE le = sw & 0xff;
@@ -186,12 +186,12 @@ void IAS::readfile_SM(WORD id, ByteDynArray &content) {
 	CARD_R_CALL(SendAPDU_SM(VarToByteArray(selectFile), VarToByteArray(fileId), resp))
 
 
-	int cnt = 0;
+	WORD cnt = 0;
 	BYTE chunk = 128;
 	DWORD sw;
 	while (true) {
 		ByteDynArray chn;
-		BYTE readFile[] = { 0x00, 0xb0, cnt >> 8, cnt & 0xff };
+		BYTE readFile[] = { 0x00, 0xb0, HIBYTE(cnt), LOBYTE(cnt) };
 		sw = SendAPDU_SM(VarToByteArray(readFile), ByteArray(), chn, &chunk);
 		if ((sw >> 8) == 0x6c)  {
 			BYTE le = sw & 0xff;

--- a/CSP/PCSC/Token.cpp
+++ b/CSP/PCSC/Token.cpp
@@ -387,9 +387,12 @@ RESULT CToken::GenerateKeyOberthur(BYTE* key,BYTE *pubkey,int modSize,ByteArray 
 {
 	init_func
 	ER_ASSERT(transmitCallback,"Carta non Connessa")
+	
+	if (modSize < 0 || modSize > MAXBYTE)
+		throw "modSize fuori intervallo";
 
 
-	BYTE data[]={key[0],key[1],pubkey[0],pubkey[1],0x00,0x000,0x00,modSize};
+	BYTE data[]={key[0],key[1],pubkey[0],pubkey[1],0x00,0x000,0x00,static_cast<BYTE>(modSize)};
 	APDU apdu(0x00,0x46,0x00,0x00,sizeof(data),data,0x00);
 	apdu.setSM(sigIn,encIn,sigOut,encOut);
 	ByteDynArray response;


### PR DESCRIPTION
The code contained a few implicit narrowing conversions that weren't entirely safe and raised compiler warnings. Where possible, I used standard Windows SDK macros like `LOBYTE` and `HIBYTE`, that safely perform all the required shifting, masking and narrowing. In a couple cases, however, I had to add full-fledged runtime range checks