### PR TITLE
64-bit correctness fixes

### DIFF
--- a/CSP/CSP/IAS.cpp
+++ b/CSP/CSP/IAS.cpp
@@ -788,7 +788,7 @@ void IAS::InitDHParam() {
 }
 
 CASNTag *GetTag(CASNTagArray &tags, DWORD id) {
-	for (int i = 0; i < tags.size(); i++) {
+	for (std::size_t i = 0; i < tags.size(); i++) {
 		if (tags[i]->tagInt() == id)
 			return tags[i];
 	}
@@ -1078,7 +1078,7 @@ void IAS::VerificaSOD(ByteArray &SOD, std::map<BYTE, ByteDynArray> &hashSet) {
 	CASNTag &CertIssuer = *issuerParser.tags[0];
 	if (issuerName.tags.size() != CertIssuer.tags.size())
 		throw CStringException("Issuer name non corrispondente");
-	for (int i = 0; i < issuerName.tags.size(); i++) {
+	for (std::size_t i = 0; i < issuerName.tags.size(); i++) {
 		CASNTag &certElem = *CertIssuer.tags[i]->tags[0];
 		CASNTag &SODElem = *issuerName.tags[i]->tags[0];
 		certElem.tags[0]->Verify(SODElem.tags[0]->content);
@@ -1096,7 +1096,7 @@ void IAS::VerificaSOD(ByteArray &SOD, std::map<BYTE, ByteDynArray> &hashSet) {
 	signedData.Child(1, 0x30).Child(0, 06).Verify(VarToByteArray(OID_SH256));
 	
 	CASNTag &hashTag = signedData.Child(2, 0x30);
-	for (int i = 0; i<hashTag.tags.size();i++) {
+	for (std::size_t i = 0; i<hashTag.tags.size();i++) {
 		CASNTag &hashDG = *(hashTag.tags[i]);
 		CASNTag &dgNum = hashDG.CheckTag(0x30).Child(0, 02);
 		CASNTag &dgHash = hashDG.Child(1, 04);

--- a/CSP/CSP/sbloccoPIN.cpp
+++ b/CSP/CSP/sbloccoPIN.cpp
@@ -111,7 +111,7 @@ DWORD WINAPI _sbloccoPIN(
 									"prima di bloccare il PUK");
 								msg.DoModal();
 								if (lpThreadParameter != nullptr)
-									PostThreadMessage((DWORD)lpThreadParameter, WM_COMMAND, 1, 0);
+									PostThreadMessage(PtrToUlong(lpThreadParameter), WM_COMMAND, 1, 0);
 
 								break;
 							}
@@ -121,7 +121,7 @@ DWORD WINAPI _sbloccoPIN(
 									"Il PUK è bloccato. La CIE non può più essere sbloccata");
 								msg.DoModal();
 								if (lpThreadParameter != nullptr)
-									PostThreadMessage((DWORD)lpThreadParameter, WM_COMMAND, 0, 0);
+									PostThreadMessage(PtrToUlong(lpThreadParameter), WM_COMMAND, 0, 0);
 								break;
 							}
 							else if (ris != 0)
@@ -131,7 +131,7 @@ DWORD WINAPI _sbloccoPIN(
 								"Il PIN è stato sbloccato correttamente");
 							msg.DoModal();
 							if (lpThreadParameter != nullptr)
-								PostThreadMessage((DWORD)lpThreadParameter, WM_COMMAND, 0, 0);
+								PostThreadMessage(PtrToUlong(lpThreadParameter), WM_COMMAND, 0, 0);
 
 						}
 						catch (CBaseException &ex) {
@@ -141,17 +141,17 @@ DWORD WINAPI _sbloccoPIN(
 								"Si è verificato un errore nella verifica del PUK");
 							msg.DoModal();
 							if (lpThreadParameter != nullptr)
-								PostThreadMessage((DWORD)lpThreadParameter, WM_COMMAND, 0, 0);
+								PostThreadMessage(PtrToUlong(lpThreadParameter), WM_COMMAND, 0, 0);
 							break;
 						}
 					}
 					else
 						if (lpThreadParameter != nullptr)
-							PostThreadMessage((DWORD)lpThreadParameter, WM_COMMAND, 1, 0);
+							PostThreadMessage(PtrToUlong(lpThreadParameter), WM_COMMAND, 1, 0);
 				}
 				else
 					if (lpThreadParameter != nullptr)
-						PostThreadMessage((DWORD)lpThreadParameter, WM_COMMAND, 1, 0);
+						PostThreadMessage(PtrToUlong(lpThreadParameter), WM_COMMAND, 1, 0);
 				break;
 			}
 		}
@@ -163,7 +163,7 @@ DWORD WINAPI _sbloccoPIN(
 				"nei lettori di smart card");
 			msg.DoModal();
 			if (lpThreadParameter != nullptr)
-				PostThreadMessage((DWORD)lpThreadParameter, WM_COMMAND, 0, 0);
+				PostThreadMessage(PtrToUlong(lpThreadParameter), WM_COMMAND, 0, 0);
 		}
 		SCardFreeMemory(hSC, readers);
 	}
@@ -181,7 +181,7 @@ DWORD WINAPI _sbloccoPIN(
 void TrayNotification(CSystemTray* tray, WPARAM uID, LPARAM lEvent) {
 	if (lEvent == WM_LBUTTONUP || lEvent== 0x405) {
 		DWORD id;
-		HANDLE thread = CreateThread(nullptr, 0, _sbloccoPIN, (LPVOID)GetCurrentThreadId(), 0, &id);
+		HANDLE thread = CreateThread(nullptr, 0, _sbloccoPIN, UlongToPtr(GetCurrentThreadId()), 0, &id);
 		tray->HideIcon();
 	}
 }

--- a/CSP/Crypto/ASNParser.cpp
+++ b/CSP/Crypto/ASNParser.cpp
@@ -49,7 +49,7 @@ bool CASNTag::isSequence()
 }
 
 void CASNTag::Free() {
-	for(int i=0;i<tags.size();i++) {
+	for(std::size_t i=0;i<tags.size();i++) {
 		delete tags[i];
 	}
 	tags.clear();
@@ -68,7 +68,7 @@ DWORD CASNTag::ContentLen() {
 
 DWORD CASNTag::tagInt() {
 	DWORD intVal = 0;
-	for (int i = 0; i < tag.size(); i++) {
+	for (std::size_t i = 0; i < tag.size(); i++) {
 		intVal = (intVal << 8) | tag[i];
 	}
 	return intVal;
@@ -85,7 +85,7 @@ DWORD CASNTag::Reparse() {
 		parser.Parse(content);
 	if (parser.tags.size() > 0) {
 		forcedSequence = true;
-		for (int i = 0; i < parser.tags.size(); i++)
+		for (std::size_t i = 0; i < parser.tags.size(); i++)
 			tags.push_back(parser.tags[i]);
 		parser.tags.clear();
 		content.clear();
@@ -125,7 +125,7 @@ RESULT CASNTag::Encode(ByteArray &data,DWORD &len) {
 	return OK;
 }
 
-CASNTag &CASNTag::Child(int num, BYTE tag) {
+CASNTag &CASNTag::Child(std::size_t num, BYTE tag) {
 	if (num >= tags.size())
 		throw CStringException("Errore nella verifica della struttura ASN1");
 	if (tags[num]->tag.size() == 1 && tags[num]->tag[0]==tag)
@@ -164,7 +164,7 @@ CASNParser::~CASNParser(void)
 }
 
 void CASNParser::Free() {
-	for(int i=0;i<tags.size();i++) {
+	for(std::size_t i=0;i<tags.size();i++) {
 		delete tags[i];
 	}
 	tags.clear();

--- a/CSP/Crypto/ASNParser.h
+++ b/CSP/Crypto/ASNParser.h
@@ -19,7 +19,7 @@ public:
 	DWORD Reparse();
 	DWORD tagInt();
 
-	CASNTag &Child(int num, BYTE tag);
+	CASNTag &Child(std::size_t num, BYTE tag);
 	void Verify(ByteArray &content);
 	CASNTag &CheckTag(BYTE tag);
 

--- a/CSP/PKCS11/Mechanism.cpp
+++ b/CSP/PKCS11/Mechanism.cpp
@@ -74,7 +74,7 @@ CEncrypt::~CEncrypt() {}
 
 CDecrypt::CDecrypt() {}
 CDecrypt::CDecrypt(CK_MECHANISM_TYPE type,CSession *Session) : CMechanism(type,Session) {
-	cacheData.pbtData=(BYTE*)0xffffffff;
+	cacheData.pbtData=(BYTE*)~(ULONG_PTR)0;
 }
 CDecrypt::~CDecrypt() {}
 

--- a/CSP/UI/Bitmap.cpp
+++ b/CSP/UI/Bitmap.cpp
@@ -34,7 +34,7 @@ if (m_hMemDC)
 Detach(); 
 m_hDC = hDC; 
 m_hMemDC = ::CreateCompatibleDC(hDC); 
-return (BOOL) m_hMemDC; 
+return m_hMemDC != nullptr; 
 } 
 
 void CBitmap::Detach() 
@@ -56,7 +56,7 @@ if (m_hBitmap)
 m_hBitmap = (HBITMAP)LoadImage((HINSTANCE)moduleInfo.getModule(), MAKEINTRESOURCE(nResourceId), IMAGE_BITMAP, 0, 0, LR_DEFAULTCOLOR);
 //( ::SHLoadImageResource(g_hInst, nResourceId); 
 ::GetObject(m_hBitmap, sizeof(BITMAP), &m_Bitmap); 
-return (BOOL) m_hBitmap; 
+return m_hBitmap != nullptr; 
 } 
 
 BOOL CBitmap::DrawBitmap(int x, int y) 

--- a/CSP/Util/Array.h
+++ b/CSP/Util/Array.h
@@ -425,7 +425,7 @@ public:
 			va_start (params, num);
 			while(true) {
 				int* cur=va_arg(params,int* );
-				if ((DWORD)cur>256) {
+				if ((DWORD_PTR)cur>256) {
 					if (*cur==term___set)
 						break;
 				}
@@ -439,7 +439,7 @@ public:
 		va_start (params, num);
 		for (int i=0;i<num;i++) {
 			void* cur=va_arg(params,void*);
-			if ((DWORD)cur<256)
+			if ((DWORD_PTR)cur<256)
 				totSize++;
 			else {
 				void *derCur = nullptr;
@@ -479,8 +479,8 @@ public:
 		va_start (params, num);
 		for (int i=0;i<num;i++) {
 			void* cur=va_arg(params,void*);
-			if ((DWORD)cur<256) {
-				pbtData[cntPos]=(BYTE)(DWORD)cur;
+			if ((DWORD_PTR)cur<256) {
+				pbtData[cntPos]=(BYTE)(DWORD_PTR)cur;
 				cntPos++;
 			}
 			else if (*(void**)cur==bdaVf) {

--- a/EsempioPCSC/EsempioPCSC.cpp
+++ b/EsempioPCSC/EsempioPCSC.cpp
@@ -29,12 +29,12 @@ int _tmain(int argc, _TCHAR* argv[])
 	}
 
 	// richiedo all'utente quale lettore utilizzare
-	for (int i = 0; i < Readers.size(); i++) {
+	for (std::size_t i = 0; i < Readers.size(); i++) {
 		std::cout << (i + 1) << ") " << Readers[i] << "\n";
 	}
 	std::cout << "Selezionare il lettore su cui è appoggiata la CIE\n";
 
-	int ReaderNum = -1;
+	std::size_t ReaderNum;
 	std::cin >> ReaderNum;
 	if (ReaderNum < 1 || ReaderNum>Readers.size()) {
 		std::cout << "Lettore inesistente\n";


### PR DESCRIPTION
- I corrected several instances of `int`/`size_t` mix-ups (different signedness, and on 64-bit, different size as well), by uniformly using `size_t`
- The Windows SDK has standard routines to pack and unpack integers into/out of opaque pointers, such as `UlongToPtr` and `PtrToUlong`: I changed casts between `DWORD` and `LPVOID` to use those routines instead (these casts are largely safe, but the compiler warns about them nevertheless)
- One of the `CDecrypt` constructors does a terrible thing: I made it marginally less terrible, and friendlier to 64-bit pointers
- Terrifying and dangerous-looking method `ByteDynArray::set` had, gems of sketchiness in the rough, several casts from pointers to `DWORD`: changed them into casts to `DWORD_PTR`, to silence compiler warnings in the 64-bit build
- I replaced very misguided casts of handles to `BOOL` with comparisons of said handles with `nullptr`, which is the intention of the code and doesn't perform an unsafe (and incorrect! because `BOOL` is not a true boolean, just a typedef for `int`) conversion