### PR TITLE
Removed CMechanism unused constructors

### DIFF
--- a/CSP/PKCS11/Mechanism.cpp
+++ b/CSP/PKCS11/Mechanism.cpp
@@ -13,7 +13,6 @@ static ByteArray baMD5DigestInfo(MD5_RSAcode,sizeof(MD5_RSAcode));
 
 namespace p11 {
 
-CMechanism::CMechanism() {}
 CMechanism::CMechanism(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session): mtType(type), pSession(std::move(Session)) {}
 CMechanism::~CMechanism() {}
 RESULT CDecrypt::checkCache(ByteArray &Data,ByteArray &Result,bool &bFound)
@@ -45,34 +44,28 @@ RESULT CDecrypt::setCache(ByteArray &Data,ByteArray &Result)
 	_return(FAIL)
 }
 
-CVerify::CVerify() {}
 CVerify::CVerify(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CMechanism(type,std::move(Session)) {}
 CVerify::~CVerify() {}
 
-CVerifyRecover::CVerifyRecover() {}
 CVerifyRecover::CVerifyRecover(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CMechanism(type,std::move(Session)) {}
 CVerifyRecover::~CVerifyRecover() {}
 
-CDigest::CDigest() {}
 CDigest::CDigest(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CMechanism(type,std::move(Session)) {}
 CDigest::~CDigest() {}
 
-CSign::CSign() {}
 CSign::CSign(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CMechanism(type,std::move(Session)) {}
 CSign::~CSign() {}
 
-CSignRecover::CSignRecover() {}
 CSignRecover::CSignRecover(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CMechanism(type,std::move(Session)) {}
 CSignRecover::~CSignRecover() {}
 
-CEncrypt::CEncrypt() {}
 CEncrypt::CEncrypt(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CMechanism(type,std::move(Session)) {}
 CEncrypt::~CEncrypt() {}
 
-CDecrypt::CDecrypt() {}
-CDecrypt::CDecrypt(CK_MECHANISM_TYPE type,CSession *Session) : CMechanism(type,Session) {
-	cacheData.pbtData=(BYTE*)~(ULONG_PTR)0;
+BYTE CDecrypt::uninitializedCacheData = 0;
+CDecrypt::CDecrypt(CK_MECHANISM_TYPE type, std::shared_ptr<CSession> Session) : CMechanism(type, Session), cacheData(&uninitializedCacheData,1) {
 }
+
 CDecrypt::~CDecrypt() {}
 
 /* ******************** */
@@ -212,7 +205,6 @@ RESULT CMD5::DigestSetOperationState(ByteArray &OperationState)
 /* ******************** */
 /*		Verify RSA		*/
 /* ******************** */
-CVerifyRSA::CVerifyRSA() {}
 CVerifyRSA::CVerifyRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CVerify(type,std::move(Session)) {}
 CVerifyRSA::~CVerifyRSA() {}
 
@@ -301,7 +293,6 @@ RESULT CVerifyRSA::VerifySetOperationState(ByteArray &OperationState)
 /* ******************** */
 /*	VerifyRecover RSA	*/
 /* ******************** */
-CVerifyRecoverRSA::CVerifyRecoverRSA() {}
 CVerifyRecoverRSA::CVerifyRecoverRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CVerifyRecover(type,std::move(Session)) {}
 CVerifyRecoverRSA::~CVerifyRecoverRSA() {}
 
@@ -382,7 +373,6 @@ RESULT CVerifyRecoverRSA::VerifyRecoverSetOperationState(ByteArray &OperationSta
 /* ******************** */
 /*		SignRSA			*/
 /* ******************** */
-CSignRSA::CSignRSA() {}
 CSignRSA::CSignRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CSign(type,std::move(Session)) {}
 CSignRSA::~CSignRSA() {}
 
@@ -435,7 +425,6 @@ RESULT CSignRSA::SignSetOperationState(ByteArray &OperationState)
 /* ******************** */
 /*	SignRecoverRSA		*/
 /* ******************** */
-CSignRecoverRSA::CSignRecoverRSA() {}
 CSignRecoverRSA::CSignRecoverRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CSignRecover(type,std::move(Session)) {}
 CSignRecoverRSA::~CSignRecoverRSA() {}
 
@@ -1175,7 +1164,6 @@ CRSAwithSHA1::~CRSAwithSHA1() {}
 /* ******************** */
 /*		EncryptRSA		*/
 /* ******************** */
-CEncryptRSA::CEncryptRSA() {}
 CEncryptRSA::CEncryptRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CEncrypt(type,std::move(Session)) {}
 CEncryptRSA::~CEncryptRSA() {}
 
@@ -1266,7 +1254,7 @@ RESULT CEncryptRSA::EncryptSetOperationState(ByteArray &OperationState)
 /* ******************** */
 /*		DecryptRSA		*/
 /* ******************** */
-CDecryptRSA::CDecryptRSA() {}
+//CDecryptRSA::CDecryptRSA() {}
 CDecryptRSA::CDecryptRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session) : CDecrypt(type,std::move(Session)) {}
 CDecryptRSA::~CDecryptRSA() {}
 

--- a/CSP/PKCS11/Mechanism.h
+++ b/CSP/PKCS11/Mechanism.h
@@ -15,7 +15,6 @@ class CMechanism
 {
 public:
 	CK_MECHANISM_TYPE mtType;
-	CMechanism();
 	CMechanism(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CMechanism(void);
 	std::shared_ptr<CSession> pSession;
@@ -24,7 +23,6 @@ public:
 class CDigest : public CMechanism
 {
 public:
-	CDigest();
 	CDigest(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CDigest();
 
@@ -42,7 +40,6 @@ class CVerify : public CMechanism
 public:
 	CK_OBJECT_HANDLE hVerifyKey;
 
-	CVerify(void);
 	CVerify(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CVerify();
 
@@ -59,7 +56,6 @@ public:
 class CVerifyRSA : public CVerify
 {
 public:
-	CVerifyRSA(void);
 	CVerifyRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CVerifyRSA();
 
@@ -75,7 +71,6 @@ class CVerifyRecover : public CMechanism
 public:
 	CK_OBJECT_HANDLE hVerifyRecoverKey;
 
-	CVerifyRecover(void);
 	CVerifyRecover(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CVerifyRecover();
 
@@ -90,7 +85,6 @@ public:
 class CVerifyRecoverRSA : public CVerifyRecover
 {
 public:
-	CVerifyRecoverRSA(void);
 	CVerifyRecoverRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CVerifyRecoverRSA();
 
@@ -105,7 +99,6 @@ class CSign : public CMechanism
 public:
 	CK_OBJECT_HANDLE hSignKey;
 
-	CSign(void);
 	CSign(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CSign();
 
@@ -122,7 +115,6 @@ public:
 class CSignRSA : public CSign
 {
 public:
-	CSignRSA(void);
 	CSignRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CSignRSA();
 
@@ -137,7 +129,6 @@ class CSignRecover : public CMechanism
 public:
 	CK_OBJECT_HANDLE hSignRecoverKey;
 
-	CSignRecover(void);
 	CSignRecover(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CSignRecover();
 
@@ -151,7 +142,6 @@ public:
 class CSignRecoverRSA : public CSignRecover
 {
 public:
-	CSignRecoverRSA(void);
 	CSignRecoverRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CSignRecoverRSA();
 
@@ -165,7 +155,6 @@ class CEncrypt : public CMechanism
 public:
 	CK_OBJECT_HANDLE hEncryptKey;
 
-	CEncrypt(void);
 	CEncrypt(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CEncrypt();
 
@@ -181,7 +170,6 @@ public:
 class CEncryptRSA : public CEncrypt
 {
 public:
-	CEncryptRSA(void);
 	CEncryptRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CEncryptRSA();
 
@@ -194,10 +182,10 @@ public:
 
 class CDecrypt : public CMechanism
 {
+	static BYTE uninitializedCacheData;
 public:
 	CK_OBJECT_HANDLE hDecryptKey;
 
-	CDecrypt(void);
 	CDecrypt(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CDecrypt();
 
@@ -219,7 +207,6 @@ public:
 class CDecryptRSA : public CDecrypt
 {
 public:
-	CDecryptRSA(void);
 	CDecryptRSA(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session);
 	virtual ~CDecryptRSA();
 
@@ -232,7 +219,6 @@ public:
 class CSHA : public CDigest
 {
 public:
-	CSHA(void);
 	CSHA(std::shared_ptr<CSession> Session);
 	virtual ~CSHA();
 
@@ -250,7 +236,6 @@ public:
 class CMD5 : public CDigest
 {
 public:
-	CMD5();
 	CMD5(std::shared_ptr<CSession> Session);
 	virtual ~CMD5();
 
@@ -268,7 +253,6 @@ public:
 class CRSA_X509 : public CSignRSA,public CSignRecoverRSA,public CVerifyRSA,public CVerifyRecoverRSA,public CEncryptRSA,public CDecryptRSA
 {
 public:
-	CRSA_X509();
 	CRSA_X509(std::shared_ptr<CSession> Session);
 	virtual ~CRSA_X509();
 
@@ -305,7 +289,6 @@ public:
 class CRSA_PKCS1 : public CSignRSA,public CSignRecoverRSA,public CVerifyRSA,public CVerifyRecoverRSA,public CEncryptRSA,public CDecryptRSA
 {
 public:
-	CRSA_PKCS1();
 	CRSA_PKCS1(std::shared_ptr<CSession> Session);
 	virtual ~CRSA_PKCS1();
 
@@ -342,7 +325,6 @@ public:
 class CSignRSAwithDigest : public CSignRSA
 {
 public:
-	CSignRSAwithDigest(void);
 	CSignRSAwithDigest(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session,CDigest *Digest);
 	virtual ~CSignRSAwithDigest();
 	
@@ -359,7 +341,6 @@ public:
 class CVerifyRSAwithDigest : public CVerifyRSA
 {
 public:
-	CVerifyRSAwithDigest(void);
 	CVerifyRSAwithDigest(CK_MECHANISM_TYPE type,std::shared_ptr<CSession> Session,CDigest *Digest);
 	virtual ~CVerifyRSAwithDigest();
 	
@@ -375,7 +356,6 @@ public:
 class CRSAwithMD5 : public CSignRSAwithDigest,public CVerifyRSAwithDigest
 {
 public:
-	CRSAwithMD5();
 	CRSAwithMD5(std::shared_ptr<CSession> Session);
 	virtual ~CRSAwithMD5();
 
@@ -385,7 +365,6 @@ public:
 class CRSAwithSHA1 : public CSignRSAwithDigest,public CVerifyRSAwithDigest
 {
 public:
-	CRSAwithSHA1();
 	CRSAwithSHA1(std::shared_ptr<CSession> Session);
 	virtual ~CRSAwithSHA1();
 


### PR DESCRIPTION
Unused constructors removed.
In CDecrypt constructor cacheData points to a static private object to mark uninitialized data
