### PR TITLE
ByteDynArray::set using variadic templates

### DIFF
--- a/CSP/Util/Array.h
+++ b/CSP/Util/Array.h
@@ -434,27 +434,23 @@ private:
 		return countHexData(data);
 	}
 
-	template<typename Arg0, typename Arg1, typename ... Args>
-	size_t internalSet(ByteArray* ba, Arg0 &&arg0, Arg1 &&arg1, Args &&... args) {
-		size_t totSize = internalSet(ba, std::forward<Arg0>(arg0));
-		ByteArray mid;
-		if (ba != NULL) {
-			mid = ba->mid(totSize);
-			ba = &mid;
-		}
-		totSize += internalSet(ba, std::forward<Arg1>(arg1), std::forward<Args>(args)...);
-		return totSize;
+	size_t internalSet(ByteArray* ba) {
+		return 0;
 	}
 
 public:
-	template<typename Arg0, typename Arg1, typename ... Args>
-	ByteDynArray& set(Arg0 &&arg0, Arg1 &&arg1, Args &&... args){
-		size_t totSize = internalSet(NULL, std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...);
+	template<typename Arg0, typename ... Args>
+	ByteDynArray& set(Arg0 &&arg0, Args &&... args) {
+		size_t totSize = internalSet(NULL, arg0) + internalSet(NULL, args...);
 		resize(totSize);
-		internalSet(this, std::forward<Arg0>(arg0), std::forward<Arg1>(arg1), std::forward<Args>(args)...);
+
+		ByteArray buffer(*this);
+		buffer = buffer.mid(internalSet(&buffer, arg0));
+		buffer = buffer.mid(internalSet(&buffer, args...));
+
 		return *this;
 	}
-
+		
 	ByteDynArray &setASN1Tag(int tag,ByteArray &content) {
 		int tl=ASN1TLength(tag);
 		int ll=ASN1LLength(content.size());

--- a/CSP/Util/IniSettings.cpp
+++ b/CSP/Util/IniSettings.cpp
@@ -71,7 +71,7 @@ void IniSettingsByteArray::GetValue(char* fileName,ByteDynArray &value) {
 	if (buf.size()==1)
 		value = defaultVal;
 	else
-		value.set(1,buf.lock());
+		value.init(buf.lock());
 }
 
 IniSettingsByteArray::~IniSettingsByteArray() {}


### PR DESCRIPTION
This implementation of ByteDynArray::set uses variadic templates to accept a variable number of arguments of 3 base types:
- a single BYTE
- a ByteArray* (or ByteDynArray*)
- an hex string

The content of the object is replaced with the concatenation of the arguments.
First the size of the resulting array is calculated then the buffer is filled.

This implementation should be easily portable and gets rid of all the hacks, also does a compile-time check of the arguments.
