### PR TITLE
Remove array template, final

### DIFF
--- a/CSP/CSP.vcxproj
+++ b/CSP/CSP.vcxproj
@@ -214,6 +214,7 @@
     <ClCompile Include="PCSC\CardLocker.cpp" />
     <ClCompile Include="CSP\CSP.cpp" />
     <ClCompile Include="crypto\DES3.cpp" />
+    <ClCompile Include="Util\Array.cpp" />
     <ClCompile Include="Util\funccallinfo.cpp" />
     <ClCompile Include="CSP\IAS.cpp" />
     <ClCompile Include="Util\IniSettings.cpp" />
@@ -259,7 +260,6 @@
     <ClInclude Include="Crypto\RSA.h" />
     <ClInclude Include="Crypto\SHA1.h" />
     <ClInclude Include="Crypto\sha256.h" />
-    <ClInclude Include="Util\Allocator.h" />
     <ClInclude Include="PCSC\APDU.h" />
     <ClInclude Include="Util\Array.h" />
     <ClInclude Include="PCSC\CardLocker.h" />

--- a/CSP/CSP.vcxproj.filters
+++ b/CSP/CSP.vcxproj.filters
@@ -192,6 +192,9 @@
     <ClCompile Include="UI\SystemTray.cpp">
       <Filter>Source Files\UI</Filter>
     </ClCompile>
+    <ClCompile Include="Util\Array.cpp">
+      <Filter>Source Files\Util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StdAfx.h">
@@ -226,9 +229,6 @@
     </ClInclude>
     <ClInclude Include="CSP\IAS.h">
       <Filter>Header Files\CSP</Filter>
-    </ClInclude>
-    <ClInclude Include="Util\Allocator.h">
-      <Filter>Header Files\Util</Filter>
     </ClInclude>
     <ClInclude Include="Util\Array.h">
       <Filter>Header Files\Util</Filter>

--- a/CSP/CSP/IAS.h
+++ b/CSP/CSP/IAS.h
@@ -36,16 +36,16 @@ class IAS
 	ByteDynArray ATR;
 	ByteDynArray Certificate;
 	ByteDynArray CardEncKey;
-	DWORD SendAPDU(ByteArray &head, ByteArray &data, ByteDynArray &resp, BYTE *le = NULL);
-	DWORD SendAPDU_SM(ByteArray &head, ByteArray &data, ByteDynArray &resp, BYTE *le = NULL);
+	DWORD SendAPDU(ByteArray &head, ByteArray &data, ByteDynArray &resp, uint8_t *le = NULL);
+	DWORD SendAPDU_SM(ByteArray &head, ByteArray &data, ByteDynArray &resp, uint8_t *le = NULL);
 	DWORD getResp(ByteDynArray &Cardresp, DWORD sw, ByteDynArray &resp);
 	DWORD getResp_SM(ByteArray &Cardresp, DWORD sw, ByteDynArray &resp);
 
 	DWORD SM(ByteArray &keyEnc, ByteArray &keySig, ByteArray &apdu, ByteArray &seq, ByteDynArray &elabResp);
 	DWORD respSM(ByteArray &keyEnc, ByteArray &keySig, ByteArray &apdu, ByteArray &seq, ByteDynArray &elabResp);
 
-	void readfile_SM(WORD id, ByteDynArray &content);
-	void readfile(WORD id, ByteDynArray &content);
+	void readfile_SM(uint16_t id, ByteDynArray &content);
+	void readfile(uint16_t id, ByteDynArray &content);
 
 	void increment(ByteArray &seq);
 	void ReadCIEType();
@@ -92,7 +92,7 @@ public:
 	bool IsEnrolled();
 	void IconaSbloccoPIN();
 
-	void VerificaSOD(ByteArray &SOD, std::map<BYTE, ByteDynArray> &hashSet);
+	void VerificaSOD(ByteArray &SOD, std::map<uint8_t, ByteDynArray> &hashSet);
 
 	void(*Callback)(int progress, char *desc,void *data);
 	void* CallbackData;

--- a/CSP/CSP/StoreProvider.cpp
+++ b/CSP/CSP/StoreProvider.cpp
@@ -89,7 +89,7 @@ LONG RegisterCard(SCARDCONTEXT hSC, const char *name, BYTE* ATR, int ATRLen) {
 	SCardForgetCardType(hSC, name);
 	ATRMask.resize(ATRLen);
 	ATRMask.fill(0xff);
-	if ((ris = SCardIntroduceCardType(hSC, name, nullptr, nullptr, 0, ATR, ATRMask.lock(), ATRMask.size()) != SCARD_S_SUCCESS))
+	if ((ris = SCardIntroduceCardType(hSC, name, nullptr, nullptr, 0, ATR, ATRMask.data(), ATRMask.size()) != SCARD_S_SUCCESS))
 	{
 		return E_UNEXPECTED;
 	}

--- a/CSP/CSP/abilitaCIE.cpp
+++ b/CSP/CSP/abilitaCIE.cpp
@@ -37,8 +37,8 @@ DWORD WINAPI _abilitaCIE(
 	try {
 
 		CSHA256 sha256;
-		std::map<BYTE, ByteDynArray> hashSet;
-		BYTE* data;
+		std::map<uint8_t, ByteDynArray> hashSet;
+		uint8_t* data;
 		DWORD len = 0;
 		ByteDynArray CertCIE;
 		ByteDynArray SOD;
@@ -111,7 +111,7 @@ DWORD WINAPI _abilitaCIE(
 							CardReadFile(&cData, DirCIE, EfIdServizi, 0, &data, &len);
 							IdServizi = ByteArray(data, len);
 							cData.pfnCspFree(data);
-							sha256.Digest(IdServizi.left(12), hashSet[0xa1]);
+							hashSet[0xa1] = sha256.Digest(IdServizi.left(12));
 
 							len = 0;
 							CardReadFile(&cData, DirCIE, EfSOD, 0, &data, &len);
@@ -122,22 +122,22 @@ DWORD WINAPI _abilitaCIE(
 							CardReadFile(&cData, DirCIE, EfIntAuth, 0, &data, &len);
 							IntAuth = ByteArray(data, len);
 							cData.pfnCspFree(data);
-							sha256.Digest(IntAuth.left(GetASN1DataLenght(IntAuth)), hashSet[0xa4]);
+							hashSet[0xa4] = sha256.Digest(IntAuth.left(GetASN1DataLenght(IntAuth)));
 
 							ByteDynArray IntAuthServizi; len = 0;
 							CardReadFile(&cData, DirCIE, EfIntAuthServizi, 0, &data, &len);
 							IntAuthServizi = ByteArray(data, len);
 							cData.pfnCspFree(data);
-							sha256.Digest(IntAuthServizi.left(GetASN1DataLenght(IntAuthServizi)), hashSet[0xa5]);
+							hashSet[0xa5] = sha256.Digest(IntAuthServizi.left(GetASN1DataLenght(IntAuthServizi)));
 
 							ByteDynArray DH; len = 0;
 							CardReadFile(&cData, DirCIE, EfDH, 0, &data, &len);
 							DH = ByteArray(data, len);
 							cData.pfnCspFree(data);
 
-							sha256.Digest(DH.left(GetASN1DataLenght(DH)), hashSet[0x1b]);
+							hashSet[0x1b] = sha256.Digest(DH.left(GetASN1DataLenght(DH)));
 							auto ias = ((IAS*)cData.pvVendorSpecific);
-							if (IdServizi != ByteArray((BYTE*)PAN, (DWORD)strnlen(PAN,20)))
+							if (IdServizi != ByteArray((uint8_t*)PAN, strnlen(PAN, 20)))
 								continue;
 
 							DWORD id;
@@ -197,12 +197,12 @@ DWORD WINAPI _abilitaCIE(
 							CardReadFile(&cData, DirCIE, EfSerial, 0, &data, &len);
 							Serial = ByteArray(data, len);
 							cData.pfnCspFree(data);
-							sha256.Digest(Serial.left(9), hashSet[0xa2]);
+							hashSet[0xa2] = sha256.Digest(Serial.left(9));
 							len = 0;
 							CardReadFile(&cData, DirCIE, EfCertCIE, 0, &data, &len);
 							CertCIE = ByteArray(data, len);
 							cData.pfnCspFree(data);
-							sha256.Digest(CertCIE.left(GetASN1DataLenght(CertCIE)), hashSet[0xa3]);
+							hashSet[0xa3] = sha256.Digest(CertCIE.left(GetASN1DataLenght(CertCIE)));
 
 							if (progWin != nullptr)
 								SendMessage(progWin, WM_COMMAND, 100 + 5, (LPARAM)"Verifica SOD");
@@ -210,7 +210,7 @@ DWORD WINAPI _abilitaCIE(
 
 							if (progWin != nullptr)
 								SendMessage(progWin, WM_COMMAND, 100 + 6, (LPARAM)"Cifratura dati");
-							ias->SetCache(PAN, CertCIE, ByteArray((BYTE*)pin.PIN, 4));
+							ias->SetCache(PAN, CertCIE, ByteArray((uint8_t*)pin.PIN, 4));
 							if (progWin != nullptr)
 								SendMessage(progWin, WM_COMMAND, 100 + 7, (LPARAM)"");
 
@@ -253,7 +253,7 @@ DWORD WINAPI _abilitaCIE(
 	catch (CBaseException &ex) {
 		std::string dump;
 		ex.DumpTree(dump);
-		MessageBox(nullptr, std::string().append("Si è verificato un errore nella verifica di autenticità del documento").append(dump).c_str(), "CIE", MB_OK);
+		MessageBox(nullptr, stdPrintf("Si è verificato un errore nella verifica di autenticità del documento :%s",dump.c_str()).c_str(), "CIE", MB_OK);
 	}
 
 	return 0;

--- a/CSP/CSP/cambioPIN.cpp
+++ b/CSP/CSP/cambioPIN.cpp
@@ -142,7 +142,8 @@ DWORD WINAPI _cambioPIN(
 				continue;
 
 			isCIE = checkCIE(conn.hCard, hSC, cData);
-			isEnrolled = ((IAS*)cData.pvVendorSpecific)->IsEnrolled();
+			if (isCIE)
+				isEnrolled = ((IAS*)cData.pvVendorSpecific)->IsEnrolled();
 
 		}
 		if (isCIE) {
@@ -192,7 +193,8 @@ DWORD WINAPI _cambioPIN(
 					if (!checkTran.isLocked())
 						return;
 					isCIE = data->checkCIE(conn.hCard, data->hSC, cData);
-					isEnrolled = ((IAS*)cData.pvVendorSpecific)->IsEnrolled();
+					if (isCIE)
+						isEnrolled = ((IAS*)cData.pvVendorSpecific)->IsEnrolled();
 				}
 				if (isCIE) {
 					if (!isEnrolled) {

--- a/CSP/CSP/sbloccoPIN.cpp
+++ b/CSP/CSP/sbloccoPIN.cpp
@@ -169,7 +169,7 @@ DWORD WINAPI _sbloccoPIN(
 	catch (CBaseException &ex) {
 		std::string dump;
 		ex.DumpTree(dump);
-		MessageBox(nullptr, std::string().append("Si è verificato un errore nella verifica di autenticità del documento").append(dump).c_str(), "CIE", MB_OK);
+		MessageBox(nullptr, stdPrintf("Si è verificato un errore nella verifica di autenticità del documento :%s",dump.c_str()).c_str(), "CIE", MB_OK);
 	}
 
 	return 0;

--- a/CSP/Crypto/AES.cpp
+++ b/CSP/Crypto/AES.cpp
@@ -22,36 +22,39 @@ CAES::~CAES(void)
 {
 }
 
-const ByteDynArray &CAES::Encode(const ByteArray &data,ByteDynArray &result)
+ByteDynArray CAES::Encode(const ByteArray &data)
 {
 	init_func
-	ByteDynArray inData;
-	ER_CALL(AES(ISOPad16(data, inData), result, AES_ENCRYPT), "Errore della cifratura AES");
+	ByteDynArray result;
+	ER_CALL(AES(ISOPad16(data), result, AES_ENCRYPT), "Errore della cifratura AES");
 	_return (result)
 	exit_func
 }
 
-const ByteDynArray &CAES::RawEncode(const ByteArray &data,ByteDynArray &result)
+ByteDynArray CAES::RawEncode(const ByteArray &data)
 {
 	init_func
+	ByteDynArray result;
 	ER_ASSERT((data.size() % AES_BLOCK_SIZE) == 0, "La dimensione dei dati da cifrare deve essere multipla di 16")
 	ER_CALL(AES(data,result,AES_ENCRYPT),"Errore della cifratura AES");
 	_return (result)
 	exit_func
 }
 
-const ByteDynArray &CAES::Decode(const ByteArray &data,ByteDynArray &result)
+ByteDynArray CAES::Decode(const ByteArray &data)
 {
 	init_func
+	ByteDynArray result;
 	ER_CALL(AES(data, result, AES_DECRYPT), "Errore della decifratura AES");
 	result.resize(RemoveISOPad(result),true);
 	_return (result)
 	exit_func
 }
 
-const ByteDynArray &CAES::RawDecode(const ByteArray &data,ByteDynArray &result)
+ByteDynArray CAES::RawDecode(const ByteArray &data)
 {
 	init_func
+	ByteDynArray result;
 	ER_ASSERT((data.size() % AES_BLOCK_SIZE) == 0, "La dimensione dei dati da cifrare deve essere multipla di 16")
 	ER_CALL(AES(data, result, AES_DECRYPT), "Errore della decifratura DES");
 	_return (result)
@@ -66,12 +69,12 @@ DWORD CAES::AES(const ByteArray &data,ByteDynArray &resp,int encOp)
 
 	AES_KEY aesKey;
 	if (encOp == AES_ENCRYPT)
-		AES_set_encrypt_key(key.lock(), key.size() * 8, &aesKey);
+		AES_set_encrypt_key(key.data(), (int)key.size() * 8, &aesKey);
 	else
-		AES_set_decrypt_key(key.lock(), key.size() * 8, &aesKey);
-	DWORD dwAppSize = data.size() - 1;
+		AES_set_decrypt_key(key.data(), (int)key.size() * 8, &aesKey);
+	size_t dwAppSize = data.size() - 1;
 	resp.resize(dwAppSize - (dwAppSize % 16) + 16);
-	AES_cbc_encrypt(data.lock(), resp.lock(), data.size(), &aesKey, iv.lock(), encOp);
+	AES_cbc_encrypt(data.data(), resp.data(), data.size(), &aesKey, iv.data(), encOp);
 	
 	_return(OK)
 	exit_func

--- a/CSP/Crypto/AES.h
+++ b/CSP/Crypto/AES.h
@@ -18,8 +18,8 @@ public:
 	~CAES(void);
 
 	void Init(const ByteArray &key);
-	const ByteDynArray &Encode(const ByteArray &data,ByteDynArray &result);
-	const ByteDynArray &Decode(const ByteArray &data,ByteDynArray &result);
-	const ByteDynArray &RawEncode(const ByteArray &data,ByteDynArray &result);
-	const ByteDynArray &RawDecode(const ByteArray &data,ByteDynArray &result);
+	ByteDynArray Encode(const ByteArray &data);
+	ByteDynArray Decode(const ByteArray &data);
+	ByteDynArray RawEncode(const ByteArray &data);
+	ByteDynArray RawDecode(const ByteArray &data);
 };

--- a/CSP/Crypto/ASNParser.cpp
+++ b/CSP/Crypto/ASNParser.cpp
@@ -5,10 +5,10 @@
 
 DWORD GetASN1DataLenght(ByteArray &data) {
 	DWORD l = 1;
-	BYTE *cur = data.lock();
+	uint8_t *cur = data.data();
 
 	int len = 0;
-	BYTE curv = cur[0];
+	uint8_t curv = cur[0];
 
 	if ((curv & 0x1f) == 0x1f)
 	{
@@ -98,7 +98,7 @@ RESULT CASNTag::Encode(ByteArray &data,DWORD &len) {
 	int tlen = (int)tag.size();
 	if (tlen==1 && tag[0]==3 && forcedSequence)
 		throw CStringException("Bit string reparsed non gestite in encode!");
-	data.copy(&tag[0], tlen);
+	data.copy(ByteArray(&tag[0], tlen));
 	DWORD clen = ContentLen();
 	int llen = ASN1LLength(clen);
 	putASN1Length(clen, data.mid(tlen));
@@ -119,7 +119,7 @@ RESULT CASNTag::Encode(ByteArray &data,DWORD &len) {
 	return OK;
 }
 
-CASNTag &CASNTag::Child(std::size_t num, BYTE tag) {
+CASNTag &CASNTag::Child(std::size_t num, uint8_t tag) {
 	if (num >= tags.size())
 		throw CStringException("Errore nella verifica della struttura ASN1");
 	if (tags[num]->tag.size() == 1 && tags[num]->tag[0]==tag)
@@ -127,7 +127,7 @@ CASNTag &CASNTag::Child(std::size_t num, BYTE tag) {
 	else
 		throw CStringException("Errore nella verifica del tag ASN1");
 }
-CASNTag &CASNTag::CheckTag(BYTE checkTag) {
+CASNTag &CASNTag::CheckTag(uint8_t checkTag) {
 	if (tag.size() != 1 || tag[0] != checkTag)
 		throw CStringException("Errore nella verifica del tag ASN1");
 	return *this;
@@ -184,12 +184,12 @@ RESULT CASNParser::Parse(ByteArray &data, CASNTagArray &tags, int startseq)
 {
 	init_func
 	DWORD l=0;
-	BYTE *cur=data.pbtData;
+	uint8_t *cur = data.data();
 	while (l<data.size()) {
 		int len=0;
 
-		std::vector<BYTE> tagv;
-		BYTE curv = cur[0];
+		std::vector<uint8_t> tagv;
+		uint8_t curv = cur[0];
 		tagv.push_back(curv);
 
         if ((curv & 0x1f) == 0x1f)
@@ -239,7 +239,7 @@ RESULT CASNParser::Parse(ByteArray &data, CASNTagArray &tags, int startseq)
 		}
 		else {
 			// è un valore singolo
-			tag->content.alloc_copy(&cur[llen+1],len);
+			tag->content= ByteArray(&cur[llen+1],len);
 		}
 		l+=len+llen+1;
 		cur+=len+llen+1;

--- a/CSP/Crypto/Base64.cpp
+++ b/CSP/Crypto/Base64.cpp
@@ -16,9 +16,9 @@ std::string &CBase64::Encode(ByteArray &data, std::string &encodedData) {
 
 	init_func
 	DWORD dwStrSize = 0;
-	CryptBinaryToString(data.lock(), data.size(), CRYPT_STRING_BASE64, NULL, &dwStrSize);
+	CryptBinaryToString(data.data(), (DWORD)data.size(), CRYPT_STRING_BASE64, NULL, &dwStrSize);
 	encodedData.resize(dwStrSize);
-	CryptBinaryToString(data.lock(),data.size(),CRYPT_STRING_BASE64,&encodedData.front(),&dwStrSize);
+	CryptBinaryToString(data.data(), (DWORD)data.size(), CRYPT_STRING_BASE64, &encodedData.front(), &dwStrSize);
 
 	return encodedData;
 	exit_func
@@ -30,7 +30,7 @@ ByteDynArray &CBase64::Decode(const char *encodedData,ByteDynArray &data) {
 	DWORD dwDataSize = 0;
 	CryptStringToBinary(encodedData, 0, CRYPT_STRING_BASE64, NULL, &dwDataSize, NULL, NULL);
 	data.resize(dwDataSize);
-	CryptStringToBinary(encodedData, 0, CRYPT_STRING_BASE64, data.lock(), &dwDataSize, NULL, NULL);
+	CryptStringToBinary(encodedData, 0, CRYPT_STRING_BASE64, data.data(), &dwDataSize, NULL, NULL);
 	
 	_return(data)
 	exit_func

--- a/CSP/Crypto/DES3.cpp
+++ b/CSP/Crypto/DES3.cpp
@@ -14,38 +14,38 @@ CDES3::CDES3(const ByteArray &key) {
 void CDES3::Init(const ByteArray &key)
 {
 	init_func
-	DWORD dwKeySize=key.size();
-	ER_ASSERT((dwKeySize % 8) == 0,"Errore nella lunghezza della chiave DES (non divisibile per 8)")
-		
-	ER_ASSERT(dwKeySize>=8 && dwKeySize<=32,"Errore nella lunghezza della chiave DES (<8 o >32)")
-	des_cblock *keyVal1 = nullptr, *keyVal2 = nullptr, *keyVal3 = nullptr;
+		size_t dwKeySize = key.size();
+	ER_ASSERT((dwKeySize % 8) == 0, "Errore nella lunghezza della chiave DES (non divisibile per 8)")
+
+		ER_ASSERT(dwKeySize >= 8 && dwKeySize <= 32, "Errore nella lunghezza della chiave DES (<8 o >32)")
+		des_cblock *keyVal1 = nullptr, *keyVal2 = nullptr, *keyVal3 = nullptr;
 
 	switch (dwKeySize) {
-		case 8:
-			memset(initVec,0,8);
-			keyVal1=keyVal2=keyVal3=(des_cblock *)key.lock(8);
-			break;
-		case 16:
-			memset(initVec,0,8);
-			keyVal1=keyVal3=(des_cblock *)key.lock(8);
-			keyVal2=(des_cblock *)key.lock(8,8);
-			break;		
-		case 24:
-			memset(initVec,0,8);
-			keyVal1=(des_cblock *)key.lock(8);
-			keyVal2=(des_cblock *)key.lock(8,8);
-			keyVal3=(des_cblock *)key.lock(8,16);
-			break;
-		case 32:
-			memcpy_s(initVec, sizeof(des_cblock), key.lock(8, 24), 8);
-			keyVal1=(des_cblock *)key.lock(8);
-			keyVal2=(des_cblock *)key.lock(8,8);
-			keyVal3=(des_cblock *)key.lock(8,16);
+	case 8:
+		memset(initVec, 0, 8);
+		keyVal1 = keyVal2 = keyVal3 = (des_cblock *)key.data();
+		break;
+	case 16:
+		memset(initVec, 0, 8);
+		keyVal1 = keyVal3 = (des_cblock *)key.data();
+		keyVal2 = (des_cblock *)key.mid(8).data();
+		break;
+	case 24:
+		memset(initVec, 0, 8);
+		keyVal1 = (des_cblock *)key.data();
+		keyVal2 = (des_cblock *)key.mid(8).data();
+		keyVal3 = (des_cblock *)key.mid(16).data();
+		break;
+	case 32:
+		memcpy_s(initVec, sizeof(des_cblock), key.mid(24).data(), 8);
+		keyVal1 = (des_cblock *)key.data();
+		keyVal2 = (des_cblock *)key.mid(8).data();
+		keyVal3 = (des_cblock *)key.mid(16).data();
 	}
 
-	des_set_key(keyVal1,k1);
-	des_set_key(keyVal2,k2);
-	des_set_key(keyVal3,k3);
+	des_set_key(keyVal1, k1);
+	des_set_key(keyVal2, k2);
+	des_set_key(keyVal3, k3);
 
 	exit_func
 }
@@ -54,36 +54,39 @@ CDES3::~CDES3(void)
 {
 }
 
-const ByteDynArray &CDES3::Encode(const ByteArray &data,ByteDynArray &result)
+ByteDynArray CDES3::Encode(const ByteArray &data)
 {
 	init_func
-	ByteDynArray inData;
-	ER_CALL(Des3(ISOPad(data,inData),result,DES_ENCRYPT),"Errore della cifratura DES");
+	ByteDynArray result;
+	ER_CALL(Des3(ISOPad(data),result,DES_ENCRYPT),"Errore della cifratura DES");
 	_return (result)
 	exit_func
 }
 
-const ByteDynArray &CDES3::RawEncode(const ByteArray &data,ByteDynArray &result)
+ByteDynArray CDES3::RawEncode(const ByteArray &data)
 {
 	init_func
+	ByteDynArray result;
 	ER_ASSERT((data.size()%8)==0,"La dimensione dei dati da cifrare deve essere multipla di 8")
 	ER_CALL(Des3(data,result,DES_ENCRYPT),"Errore della cifratura DES");
 	_return (result)
 	exit_func
 }
 
-const ByteDynArray &CDES3::Decode(const ByteArray &data,ByteDynArray &result)
+ByteDynArray CDES3::Decode(const ByteArray &data)
 {
 	init_func
+	ByteDynArray result;
 	ER_CALL(Des3(data,result,DES_DECRYPT),"Errore della decifratura DES");
 	result.resize(RemoveISOPad(result),true);
 	_return (result)
 	exit_func
 }
 
-const ByteDynArray &CDES3::RawDecode(const ByteArray &data,ByteDynArray &result)
+ByteDynArray CDES3::RawDecode(const ByteArray &data)
 {
 	init_func
+	ByteDynArray result;
 	ER_ASSERT((data.size()%8)==0,"La dimensione dei dati da cifrare deve essere multipla di 8")
 	ER_CALL(Des3(data,result,DES_DECRYPT),"Errore della decifratura DES");
 	_return (result)
@@ -96,9 +99,9 @@ DWORD CDES3::Des3(const ByteArray &data,ByteDynArray &resp,int encOp)
 
 	des_cblock iv;
 	memcpy_s(iv, sizeof(des_cblock), initVec, sizeof(initVec));
-	DWORD dwAppSize=data.size()-1;
+	size_t dwAppSize=data.size()-1;
 	resp.resize(dwAppSize-(dwAppSize % 8)+8);
-	des_ede3_cbc_encrypt(data.lock(),resp.lock(),data.size(),k1,k2,k3,&iv,encOp);
+	des_ede3_cbc_encrypt(data.data(),resp.data(),(long)data.size(),k1,k2,k3,&iv,encOp);
 	_return(OK)
 	exit_func
 	_return(FAIL)

--- a/CSP/Crypto/DES3.h
+++ b/CSP/Crypto/DES3.h
@@ -18,8 +18,8 @@ public:
 	~CDES3(void);
 
 	void Init(const ByteArray &key);
-	const ByteDynArray &Encode(const ByteArray &data,ByteDynArray &result);
-	const ByteDynArray &Decode(const ByteArray &data,ByteDynArray &result);
-	const ByteDynArray &RawEncode(const ByteArray &data,ByteDynArray &result);
-	const ByteDynArray &RawDecode(const ByteArray &data,ByteDynArray &result);
+	ByteDynArray Encode(const ByteArray &data);
+	ByteDynArray Decode(const ByteArray &data);
+	ByteDynArray RawEncode(const ByteArray &data);
+	ByteDynArray RawDecode(const ByteArray &data);
 };

--- a/CSP/Crypto/MAC.cpp
+++ b/CSP/Crypto/MAC.cpp
@@ -14,34 +14,33 @@ CMAC::CMAC(ByteArray &key) {
 void CMAC::Init(ByteArray &key)
 {
 	init_func
-	DWORD dwKeySize=key.size();
+	size_t dwKeySize=key.size();
 	ER_ASSERT((dwKeySize % 8) == 0,"Errore nella lunghezza della chiave MAC (non divisibile per 8)")
 		
 	ER_ASSERT(dwKeySize>=8 && dwKeySize<=32,"Errore nella lunghezza della chiave MAC (<8 o >32)")
-
 	des_cblock *keyVal1 = nullptr, *keyVal2 = nullptr, *keyVal3 = nullptr;
 
 	switch (dwKeySize) {
 		case 8:
 			memset(initVec,0,8);
-			keyVal1=keyVal2=keyVal3=(des_cblock *)key.lock(8);
+			keyVal1 = keyVal2 = keyVal3 = (des_cblock *)key.data();
 			break;
 		case 16:
 			memset(initVec,0,8);
-			keyVal1=keyVal3=(des_cblock *)key.lock(8);
-			keyVal2=(des_cblock *)key.lock(8,8);
+			keyVal1 = keyVal3 = (des_cblock *)key.data();
+			keyVal2 = (des_cblock *)key.mid(8).data();
 			break;		
 		case 24:
 			memset(initVec,0,8);
-			keyVal1=(des_cblock *)key.lock(8);
-			keyVal2=(des_cblock *)key.lock(8,8);
-			keyVal3=(des_cblock *)key.lock(8,16);
+			keyVal1 = (des_cblock *)key.data();
+			keyVal2 = (des_cblock *)key.mid(8).data();
+			keyVal3 = (des_cblock *)key.mid(16).data();
 			break;
 		case 32:
-			memcpy_s(initVec, sizeof(des_cblock), key.lock(8, 24), 8);
-			keyVal1=(des_cblock *)key.lock(8);
-			keyVal2=(des_cblock *)key.lock(8,8);
-			keyVal3=(des_cblock *)key.lock(8,16);
+			memcpy_s(initVec, sizeof(des_cblock), key.mid(24).data(), 8);
+			keyVal1 = (des_cblock *)key.data();
+			keyVal2 = (des_cblock *)key.mid(8).data();
+			keyVal3 = (des_cblock *)key.mid(16).data();
 	}
 
 	des_set_key(keyVal1,k1);
@@ -54,9 +53,10 @@ CMAC::~CMAC(void)
 {
 }
 
-const ByteDynArray &CMAC::Mac(const ByteArray &data,ByteDynArray &result)
+ByteDynArray CMAC::Mac(const ByteArray &data)
 {
 	init_func
+	ByteDynArray result;
 	ER_CALL(_Mac(data,result),"Errore nel calcolo del MAC");
 	_return (result)
 	exit_func
@@ -69,14 +69,14 @@ DWORD CMAC::_Mac(const ByteArray &data,ByteDynArray &resp)
 	des_cblock iv;
 	memcpy_s(iv, sizeof(des_cblock), initVec, sizeof(initVec));
 
-	DWORD dwANSILen=ANSIPadLen(data.size());
+	size_t dwANSILen=ANSIPadLen(data.size());
 	if (data.size()>8) {
 		ByteDynArray baOutTmp(dwANSILen-8);
-		des_ncbc_encrypt(data.lock(dwANSILen-8),baOutTmp.lock(),dwANSILen-8,k1,&iv,DES_ENCRYPT);
+		des_ncbc_encrypt(data.data(), baOutTmp.data(), (long)dwANSILen - 8, k1, &iv, DES_ENCRYPT);
 	}
-	BYTE dest[8];
-	des_ede3_cbc_encrypt(data.lock(-1,dwANSILen-8),dest,data.size()-dwANSILen+8,k1,k2,k3,&iv,DES_ENCRYPT);
-	resp.alloc_copy(dest,8);
+	uint8_t dest[8];
+	des_ede3_cbc_encrypt(data.mid(dwANSILen - 8).data(), dest, (long)(data.size() - dwANSILen) + 8, k1, k2, k3, &iv, DES_ENCRYPT);
+	resp = ByteArray(dest, 8);
 
 	_return(OK)
 	exit_func

--- a/CSP/Crypto/MAC.h
+++ b/CSP/Crypto/MAC.h
@@ -14,6 +14,6 @@ public:
 	~CMAC(void);
 
 	void Init(ByteArray &key);
-	const ByteDynArray &Mac(const ByteArray &data,ByteDynArray &result);
+	ByteDynArray Mac(const ByteArray &data);
 
 };

--- a/CSP/Crypto/RSA.h
+++ b/CSP/Crypto/RSA.h
@@ -10,7 +10,7 @@ public:
 	CRSA(ByteArray &mod, ByteArray &exp);
 	~CRSA(void);
 
-	RESULT RSA_PURE(ByteArray &data,ByteDynArray &resp);
+	ByteDynArray RSA_PURE(ByteArray &data);
 	RESULT GenerateKey(DWORD size, ByteDynArray &module, ByteDynArray &pubexp, ByteDynArray &privexp);
-	DWORD dwKeySize;
+	size_t dwKeySize;
 };

--- a/CSP/Crypto/SHA1.cpp
+++ b/CSP/Crypto/SHA1.cpp
@@ -5,13 +5,10 @@
 static char *szCompiledFile=__FILE__;
 
 
-ByteDynArray &CSHA1::Digest(ByteArray data,ByteDynArray &digest)
+ByteDynArray CSHA1::Digest(ByteArray data)
 {
-	init_func
+	ByteDynArray digest(SHA_DIGEST_LENGTH);
+	SHA1(data.data(), data.size(), digest.data());
 
-	digest.resize(SHA_DIGEST_LENGTH);
-	SHA1(data.lock(),data.size(),digest.lock());
-
-	_return(digest)
-	exit_func
+	return digest;
 }

--- a/CSP/Crypto/SHA1.h
+++ b/CSP/Crypto/SHA1.h
@@ -6,5 +6,5 @@
 class CSHA1
 {
 public:
-	ByteDynArray &Digest(ByteArray data,ByteDynArray &digest);
+	ByteDynArray Digest(ByteArray data);
 };

--- a/CSP/Crypto/SHA256.cpp
+++ b/CSP/Crypto/SHA256.cpp
@@ -3,22 +3,10 @@
 
 static char *szCompiledFile=__FILE__;
 
-CSHA256::CSHA256()
+ByteDynArray CSHA256::Digest(ByteArray &data)
 {
-}
-
-CSHA256::~CSHA256(void)
-{
-}
-
-RESULT CSHA256::Digest(ByteArray &data,ByteDynArray &resp)
-{
-	init_func
-	resp.resize(SHA256_DIGEST_LENGTH);
+	ByteDynArray resp(SHA256_DIGEST_LENGTH);
 	
-	ER_ASSERT(SHA256(data.lock(),data.size(),resp.lock())!=NULL,"Errore nel calcolo dello SHA256")
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
+	ER_ASSERT(SHA256(data.data(), data.size(), resp.data()) != NULL, "Errore nel calcolo dello SHA256")
+	return resp;
 }

--- a/CSP/Crypto/sha256.h
+++ b/CSP/Crypto/sha256.h
@@ -7,8 +7,5 @@
 class CSHA256
 {
 public:
-	CSHA256(void);
-	~CSHA256(void);
-
-	RESULT Digest(ByteArray &data,ByteDynArray &resp);
+	ByteDynArray Digest(ByteArray &data);
 };

--- a/CSP/PCSC/APDU.h
+++ b/CSP/PCSC/APDU.h
@@ -7,19 +7,19 @@ class APDU
 {
 public:
 	APDU();
-	APDU(BYTE CLA,BYTE INS,BYTE P1,BYTE P2,BYTE LC,BYTE *pData,BYTE LE);
-	APDU(BYTE CLA,BYTE INS,BYTE P1,BYTE P2,BYTE LC,BYTE *pData);
-	APDU(BYTE CLA,BYTE INS,BYTE P1,BYTE P2,BYTE LE);
-	APDU(BYTE CLA,BYTE INS,BYTE P1,BYTE P2);
+	APDU(uint8_t CLA,uint8_t INS,uint8_t P1,uint8_t P2,uint8_t LC,uint8_t *pData,uint8_t LE);
+	APDU(uint8_t CLA,uint8_t INS,uint8_t P1,uint8_t P2,uint8_t LC,uint8_t *pData);
+	APDU(uint8_t CLA,uint8_t INS,uint8_t P1,uint8_t P2,uint8_t LE);
+	APDU(uint8_t CLA,uint8_t INS,uint8_t P1,uint8_t P2);
 	~APDU();
 
-	BYTE btINS;	//INS dell'APDU
-	BYTE btCLA;	//CLA dell'APDU
-	BYTE btP1;	//P1 dell'APDU
-	BYTE btP2;	//P2 dell'APDU
-	BYTE btLC;	//LC dell'APDU
+	uint8_t btINS;	//INS dell'APDU
+	uint8_t btCLA;	//CLA dell'APDU
+	uint8_t btP1;	//P1 dell'APDU
+	uint8_t btP2;	//P2 dell'APDU
+	uint8_t btLC;	//LC dell'APDU
 	bool bLC;	//flag: il campo dati è da includere? (caso 1 e 3)
-	BYTE *pbtData;	//campo dati dell'APDU
-	BYTE btLE;	//flag: LE è da includere? (caso 2 e 4)
+	uint8_t *pbtData;	//campo dati dell'APDU
+	uint8_t btLE;	//flag: LE è da includere? (caso 2 e 4)
 	bool bLE;	//LE dell'APDU
 };

--- a/CSP/PCSC/Token.h
+++ b/CSP/PCSC/Token.h
@@ -16,7 +16,7 @@ class CCardLocker;
 class CToken
 {
 public:
-	typedef int(*TokenTransmitCallback)(void *data, BYTE *apdu, DWORD apduSize, BYTE *resp, DWORD *respSize);
+	typedef int(*TokenTransmitCallback)(void *data, uint8_t *apdu, DWORD apduSize, uint8_t *resp, DWORD *respSize);
 
 private:
 	TokenTransmitCallback transmitCallback;
@@ -26,9 +26,8 @@ public:
 	~CToken();
 
 	RESULT Connect(char * reader);
-	RESULT Select(BYTE *id,DWORD *size=NULL);
 	RESULT SelectMF();
-	RESULT BinaryRead(ByteDynArray &data,WORD start,BYTE size);
+	RESULT BinaryRead(ByteDynArray &data, uint16_t start, uint8_t size);
 	RESULT Reset(bool unpower = false);
 
 	RESULT setTransmitCallback(TokenTransmitCallback func,void *data);

--- a/CSP/PKCS11/Mechanism.h
+++ b/CSP/PKCS11/Mechanism.h
@@ -182,7 +182,7 @@ public:
 
 class CDecrypt : public CMechanism
 {
-	static BYTE uninitializedCacheData;
+	static uint8_t uninitializedCacheData;
 public:
 	CK_OBJECT_HANDLE hDecryptKey;
 

--- a/CSP/PKCS11/P11Object.cpp
+++ b/CSP/PKCS11/P11Object.cpp
@@ -18,16 +18,7 @@ CP11Object::CP11Object(CK_OBJECT_CLASS objClass,void *TemplateData)
 RESULT CP11Object::addAttribute(CK_ATTRIBUTE_TYPE type,ByteArray &data)
 {
 	init_func
-	attributes[type].alloc_copy(data);
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-RESULT CP11Object::addAttribute(CK_ATTRIBUTE_TYPE type,BYTE *pData,DWORD dwLen)
-{
-	init_func
-	attributes[type].alloc_copy(pData,dwLen);
+	attributes[type] = data;
 	_return(OK)
 	exit_func
 	_return(FAIL)
@@ -70,7 +61,7 @@ CK_RV CP11Object::GetAttributeValue(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount
 			else {
 				if (attr->size()>ulValLen)
 					_return(CKR_BUFFER_TOO_SMALL)
-					memcpy_s(pTemplate[i].pValue, attr->size(), attr->lock(), attr->size());
+					memcpy_s(pTemplate[i].pValue, attr->size(), attr->data(), attr->size());
 				pTemplate[i].ulValueLen=attr->size();
 			}
 		}

--- a/CSP/PKCS11/P11Object.h
+++ b/CSP/PKCS11/P11Object.h
@@ -26,7 +26,6 @@ public:
 	CK_OBJECT_CLASS ObjClass;
 	AttributeMap attributes;
 	RESULT addAttribute(CK_ATTRIBUTE_TYPE type,ByteArray &data);
-	RESULT addAttribute(CK_ATTRIBUTE_TYPE type,BYTE *pData,DWORD dwLen);
 	virtual RESULT getAttribute(CK_ATTRIBUTE_TYPE type,ByteArray *&pValue);
 
 	virtual CK_RV GetAttributeValue(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount);

--- a/CSP/PKCS11/PKCS11Functions.cpp
+++ b/CSP/PKCS11/PKCS11Functions.cpp
@@ -331,7 +331,7 @@ CK_RV CK_ENTRY C_OpenSession(CK_SLOT_ID slotID, CK_FLAGS flags, CK_VOID_PTR pApp
 	EDF_CALL(CSession::AddSession(std::move(pSession),*phSession),
 		ERR_CANT_ADD_SESSION)
 
-	if (Log.bEnabled) {
+	if (Log.Enabled) {
 		Log.writePure("Sessione: %i",*phSession);
 		Log.writePure("Lettore: %s",pSlot->szName.c_str());
 		Log.writePure("CardManager: %s",pSlot->pTemplate->szName.c_str());
@@ -781,7 +781,7 @@ CK_RV CK_ENTRY C_Digest(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG 
 
 	ByteArray Digest(pDigest, *pulDigestLen);
 	DF_CALL(pSession->Digest(ByteArray(pData, ulDataLen), Digest))
-	*pulDigestLen=Digest.dwSize;
+	*pulDigestLen = (CK_ULONG)Digest.size();
 
 	_return(CKR_OK)
 	exit_main_func
@@ -810,7 +810,7 @@ CK_RV CK_ENTRY C_DigestFinal(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pDigest, CK
 
 	ByteArray Digest(pDigest, *pulDigestLen);
 	pSession->DigestFinal(Digest);
-	*pulDigestLen=Digest.size();
+	*pulDigestLen = (CK_ULONG)Digest.size();
 
 	_return(CKR_OK)
 	exit_main_func
@@ -903,7 +903,7 @@ CK_RV CK_ENTRY C_FindObjectsInit(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pT
 	logParam(pTemplate)
 	logParam(ulCount)
 
-	if (Log.bLogParam) {
+	if (Log.LogParam) {
 		for (DWORD i=0;i<ulCount;i++) {
 			Log.writePure("Template %i:",i+1);
 			Log.writePure("Type: %s (%x)",getAttributeName(pTemplate[i].type),pTemplate[i].type);
@@ -1209,7 +1209,7 @@ CK_RV CK_ENTRY C_Sign(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG ul
 
 	ByteArray Signature(pSignature,*pulSignatureLen);
 	DF_CALL(pSession->Sign(ByteArray(pData,ulDataLen),Signature))
-	*pulSignatureLen=Signature.size();
+		*pulSignatureLen = (CK_ULONG)Signature.size();
 	_return(CKR_OK)
 	exit_main_func
 	_return(CKR_GENERAL_ERROR)	
@@ -1240,7 +1240,7 @@ CK_RV CK_ENTRY C_SignFinal(CK_SESSION_HANDLE hSession,CK_BYTE_PTR pSignature,CK_
 
 	ByteArray Signature(pSignature,*pulSignatureLen);
 	DF_CALL(pSession->SignFinal(Signature))
-	*pulSignatureLen=Signature.dwSize;
+		*pulSignatureLen = (CK_ULONG)Signature.size();
 
 	_return(CKR_OK)
 	exit_main_func
@@ -1363,7 +1363,7 @@ CK_RV CK_ENTRY C_SignRecover(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_U
 
 	ByteArray Signature(pSignature,*pulSignatureLen);
 	DF_CALL(pSession->SignRecover(ByteArray(pData,ulDataLen),Signature))
-	*pulSignatureLen=Signature.size();
+		*pulSignatureLen = (CK_ULONG)Signature.size();
 	_return(CKR_OK)
 	exit_main_func
 	_return(CKR_GENERAL_ERROR)	
@@ -1424,7 +1424,7 @@ CK_RV CK_ENTRY C_VerifyRecover(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pSignatur
 
 	ByteArray Data(pData,*pulDataLen);
 	DF_CALL(pSession->VerifyRecover(ByteArray(pSignature,ulSignatureLen),Data))
-	*pulDataLen=Data.size();
+		*pulDataLen = (CK_ULONG)Data.size();
 	_return(CKR_OK)
 	exit_main_func
 	_return(CKR_GENERAL_ERROR)	
@@ -1571,7 +1571,7 @@ CK_RV CK_ENTRY C_Encrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG
 
 	ByteArray EncryptedData(pEncryptedData, *pulEncryptedDataLen);
 	DF_CALL(pSession->Encrypt(ByteArray(pData, ulDataLen), EncryptedData))
-	*pulEncryptedDataLen=EncryptedData.dwSize;
+		*pulEncryptedDataLen = (CK_ULONG)EncryptedData.size();
 
 	_return(CKR_OK)
 	exit_main_func
@@ -1602,7 +1602,7 @@ CK_RV CK_ENTRY C_EncryptFinal(CK_SESSION_HANDLE hSession,CK_BYTE_PTR pEncryptedD
 
 	ByteArray EncryptedData(pEncryptedData, *pulEncryptedDataLen);
 	DF_CALL(pSession->EncryptFinal(EncryptedData))
-	*pulEncryptedDataLen=EncryptedData.dwSize;
+		*pulEncryptedDataLen = (CK_ULONG)EncryptedData.size();
 
 	_return(CKR_OK)
 	exit_main_func
@@ -1669,7 +1669,7 @@ CK_RV CK_ENTRY C_EncryptUpdate(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pPart, CK
 
 	ByteArray EncryptedPart(pEncryptedPart, *pulEncryptedPartLen);
 	DF_CALL(pSession->EncryptUpdate(ByteArray(pPart,ulPartLen),EncryptedPart))
-	*pulEncryptedPartLen=EncryptedPart.dwSize;
+		*pulEncryptedPartLen = (CK_ULONG)EncryptedPart.size();
 
 	_return(CKR_OK)
 	exit_main_func
@@ -1698,7 +1698,7 @@ CK_RV CK_ENTRY C_Decrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncryptedData,
 
 	ByteArray Data(pData, *pulDataLen);
 	DF_CALL(pSession->Decrypt(ByteArray(pEncryptedData, ulEncryptedDataLen), Data))
-	*pulDataLen=Data.size();
+		*pulDataLen = (CK_ULONG)Data.size();
 	
 	_return(CKR_OK)
 	exit_main_func
@@ -1729,7 +1729,7 @@ CK_RV CK_ENTRY C_DecryptFinal(CK_SESSION_HANDLE hSession,CK_BYTE_PTR pData,CK_UL
 
 	ByteArray Data(pData, *pulDataLen);
 	DF_CALL(pSession->DecryptFinal(Data))
-	*pulDataLen=Data.size();
+		*pulDataLen = (CK_ULONG)Data.size();
 
 	_return(CKR_OK)
 	exit_main_func
@@ -1796,7 +1796,7 @@ CK_RV CK_ENTRY C_DecryptUpdate(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncrypte
 
 	ByteArray Part(pPart, *pulPartLen);
 	DF_CALL(pSession->DecryptUpdate(ByteArray(pEncryptedPart, ulEncryptedPartLen), Part))
-	*pulPartLen=Part.dwSize;
+		*pulPartLen = (CK_ULONG)Part.size();
 
 	_return(CKR_OK)
 	exit_main_func
@@ -1994,7 +1994,7 @@ CK_RV CK_ENTRY C_GetOperationState(CK_SESSION_HANDLE hSession,CK_BYTE_PTR pOpera
 
 	ByteArray OperationState(pOperationState,*pulOperationStateLen);
 	DF_CALL(pSession->GetOperationState(OperationState))
-	*pulOperationStateLen=OperationState.size();
+		*pulOperationStateLen = (CK_ULONG)OperationState.size();
 
 	_return(CKR_OK)
 	exit_main_func

--- a/CSP/PKCS11/Slot.h
+++ b/CSP/PKCS11/Slot.h
@@ -94,7 +94,7 @@ public:
 	void Final();
 
 	RESULT AddP11Object(std::shared_ptr<CP11Object> object);
-	RESULT FindP11Object(CK_OBJECT_CLASS objClass,CK_ATTRIBUTE_TYPE attr,BYTE *val,int valLen,std::shared_ptr<CP11Object>&ppObject);
+	RESULT FindP11Object(CK_OBJECT_CLASS objClass, CK_ATTRIBUTE_TYPE attr, CK_BYTE *val, int valLen, std::shared_ptr<CP11Object>&ppObject);
 	RESULT DelP11Object(const std::shared_ptr<CP11Object>& pObject);
 	RESULT ClearP11Objects();
 	RESULT IsTokenPresent(bool *bPresent);

--- a/CSP/PKCS11/session.cpp
+++ b/CSP/PKCS11/session.cpp
@@ -5,637 +5,641 @@
 #include "../crypto\rsa.h"
 #include "../util/tlv.h"
 
-static char *szCompiledFile=__FILE__;
+static char *szCompiledFile = __FILE__;
+
 
 namespace {
 
-template<class T>
-class resetter;
+	template<class T>
+	class resetter;
 
-template<class T>
-resetter<T> make_resetter(T&) noexcept;
+	template<class T>
+	resetter<T> make_resetter(T&) noexcept;
 
-template<class T>
-class resetter<std::unique_ptr<T>>
-{
-private:
-	std::unique_ptr<T> * m_p;
-
-	friend resetter<std::unique_ptr<T>> make_resetter<std::unique_ptr<T>>(std::unique_ptr<T>& p) noexcept;
-	resetter(std::unique_ptr<T>& p) noexcept : m_p(&p) {}
-
-	void reset() noexcept(noexcept(m_p->reset()))
+	template<class T>
+	class resetter<std::unique_ptr<T>>
 	{
-		if (m_p)
-			m_p->reset();
+	private:
+		std::unique_ptr<T> * m_p;
 
-		m_p = nullptr;
-	}
+		friend resetter<std::unique_ptr<T>> make_resetter<std::unique_ptr<T>>(std::unique_ptr<T>& p) noexcept;
+		resetter(std::unique_ptr<T>& p) noexcept : m_p(&p) {}
 
-public:
-	resetter(const resetter&) = delete;
-	resetter(resetter&& other) noexcept : m_p(std::exchange(other.m_p, nullptr)) {}
+		void reset() noexcept(noexcept(m_p->reset()))
+		{
+			if (m_p)
+				m_p->reset();
 
-	resetter& operator=(const resetter&) = delete;
+			m_p = nullptr;
+		}
 
-	resetter& operator=(resetter&& other) noexcept(noexcept(reset()))
+	public:
+		resetter(const resetter&) = delete;
+		resetter(resetter&& other) noexcept : m_p(std::exchange(other.m_p, nullptr)) {}
+
+		resetter& operator=(const resetter&) = delete;
+
+		resetter& operator=(resetter&& other) noexcept(noexcept(reset()))
+		{
+			reset();
+			m_p = std::exchange(other.m_p, nullptr);
+			return *this;
+		}
+
+		~resetter() noexcept(noexcept(reset())) 
+		{
+			reset();
+		}
+
+		void release() noexcept
+		{
+			m_p = nullptr;
+		}
+	};
+
+	template<class T>
+	resetter<T> make_resetter(T& p) noexcept
 	{
-		reset();
-		m_p = std::exchange(other.m_p, nullptr);
-		return *this;
+		return resetter<T>(p);
 	}
-
-	~resetter() noexcept(noexcept(reset())) { reset(); }
-
-	void release() noexcept
-	{
-		m_p = nullptr;
-	}
-};
-
-template<class T>
-resetter<T> make_resetter(T& p) noexcept
-{
-	return resetter<T>(p);
-}
 
 }
 
 namespace p11 {
 
-DWORD CSession::dwSessionCnt=1;
-SessionMap CSession::g_mSessions;
+	DWORD CSession::dwSessionCnt = 1;
+	SessionMap CSession::g_mSessions;
 
-CSession::CSession()
-{
-	init_func_internal
-	pSlot=NULL;
-	bFindInit=false;
-	exit_func_internal
-}
-
-RESULT CSession::GetNewSessionID(CK_SLOT_ID &hSlotID) {
-	init_func	
-
-	hSlotID=dwSessionCnt;
-	dwSessionCnt++;
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-RESULT CSession::AddSession(std::unique_ptr<CSession> pSession,CK_SESSION_HANDLE &hSession)
-{
-	init_func
-	P11ER_CALL(GetNewSessionID(pSession->hSessionHandle),
-		ERR_GET_NEW_SESSION)
-
-	g_mSessions.insert(std::make_pair(pSession->hSessionHandle,std::move(pSession)));
-	hSession=pSession->hSessionHandle;
-	P11ER_CALL(pSession->pSlot->pTemplate->FunctionList.templateInitSession(pSession->pSlot->pTemplateData),
-		ERR_INIT_SESSION)
-
-	pSession->pSlot->dwSessionCount++;
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-RESULT CSession::DeleteSession(CK_SESSION_HANDLE hSessionHandle)
-{
-	init_func
-	std::shared_ptr<CSession> pSession;
-	P11ER_CALL(GetSessionFromID(hSessionHandle,pSession),
-		ERR_CANT_GET_SESSION);
-
-	ER_ASSERT(pSession,ERR_SESSION_NOT_OPENED);
-
-	pSession->pSlot->dwSessionCount--;
-	if (pSession->pSlot->dwSessionCount==0) {
-		if (pSession->pSlot->User!=CKU_NOBODY) {
-			P11ER_CALL(pSession->Logout(),
-				ERR_CANT_LOGOUT)
-		}
+	CSession::CSession()
+	{
+		init_func_internal
+			pSlot = NULL;
+		bFindInit = false;
+		exit_func_internal
 	}
 
-	P11ER_CALL(pSession->pSlot->pTemplate->FunctionList.templateFinalSession(pSession->pSlot->pTemplateData),
-		ERR_FINAL_SESSION)
+	RESULT CSession::GetNewSessionID(CK_SLOT_ID &hSlotID) {
+		init_func
 
-	g_mSessions.erase(hSessionHandle);
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-RESULT CSession::GetSessionFromID(CK_SESSION_HANDLE hSessionHandle,std::shared_ptr<CSession>&pSession)
-{
-	init_func
-	pSession.reset();
-	SessionMap::const_iterator pPair;
-	pPair=g_mSessions.find(hSessionHandle);
-	if (pPair==g_mSessions.end()) {
-		pSession.reset();
+			hSlotID = dwSessionCnt;
+		dwSessionCnt++;
 		_return(OK)
+			exit_func
+			_return(FAIL)
 	}
-	pSession=pPair->second;
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
 
-/* ******************* */
-/*    LOGIN e LOGOUT   */
-/* ******************* */
+	RESULT CSession::AddSession(std::unique_ptr<CSession> pSession, CK_SESSION_HANDLE &hSession)
+	{
+		init_func
+			P11ER_CALL(GetNewSessionID(pSession->hSessionHandle),
+			ERR_GET_NEW_SESSION)
 
-CK_RV CSession::Login(CK_USER_TYPE userType, CK_CHAR_PTR pPin, CK_ULONG ulPinLen)
-{
-	init_func
+			g_mSessions.insert(std::make_pair(pSession->hSessionHandle, std::move(pSession)));
+		hSession = pSession->hSessionHandle;
+		P11ER_CALL(pSession->pSlot->pTemplate->FunctionList.templateInitSession(pSession->pSlot->pTemplateData),
+			ERR_INIT_SESSION)
 
-	if (pSlot->User==CKU_USER && userType == CKU_SO)
-		_return(CKR_USER_ANOTHER_ALREADY_LOGGED_IN)
-	if (pSlot->User==CKU_SO && userType == CKU_USER )
-		_return(CKR_USER_ANOTHER_ALREADY_LOGGED_IN)
-	bool bExistsRO=false;
-	if (userType == CKU_SO) {
-		P11ER_CALL(ExistsRO(bExistsRO),
-			ERR_RO_SESSION)
-		if (bExistsRO)
-			_return(CKR_SESSION_READ_ONLY_EXISTS)
+			pSession->pSlot->dwSessionCount++;
+
+		_return(OK)
+			exit_func
+			_return(FAIL)
 	}
-	if (pSlot->User!=CKU_NOBODY)
-		_return(CKR_USER_ALREADY_LOGGED_IN)
 
-	ByteArray baPin(pPin, ulPinLen);
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateLogin(pSlot->pTemplateData,userType, baPin),
-		ERR_CANT_LOGIN)
+	RESULT CSession::DeleteSession(CK_SESSION_HANDLE hSessionHandle)
+	{
+		init_func
+			std::shared_ptr<CSession> pSession;
+		P11ER_CALL(GetSessionFromID(hSessionHandle, pSession),
+			ERR_CANT_GET_SESSION);
 
-	pSlot->User=userType;
+		ER_ASSERT(pSession, ERR_SESSION_NOT_OPENED);
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::Logout() {
-	init_func
-
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateLogout(pSlot->pTemplateData,pSlot->User),
-		ERR_CANT_LOGOUT)
-
-	for (DWORD i=0;i<pSlot->P11Objects.size();i++) {
-		auto p11Obj=pSlot->P11Objects[i];
-		bool bPrivate;
-		P11ER_CALL(p11Obj->IsPrivate(bPrivate),
-			ERR_GET_PRIVATE)
-
-		if (bPrivate)
-			pSlot->DelObjectHandle(p11Obj);
-	}
-	pSlot->User=CKU_NOBODY;
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-/* ******************* */
-/*    Find Objects     */
-/* ******************* */
-
-CK_RV CSession::FindObjectsInit(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount)
-{
-	init_func
-	if (bFindInit)
-		_return(CKR_OPERATION_ACTIVE)
-	findResult.clear();
-	if (ulCount==0) {
-		for(DWORD i=0;i<pSlot->P11Objects.size();i++) {
-			CK_OBJECT_HANDLE hObject;
-			RESULT ris;
-			if (ris=pSlot->GetIDFromObject(pSlot->P11Objects[i],hObject)) {
-				continue;
-			}
-			else {
-				findResult.push_back(hObject);
-				if (Log.bLogParam) {
-					ByteArray *Label=NULL;
-					pSlot->P11Objects[i]->getAttribute(CKA_LABEL,Label);
-					Log.writePure("Object found %i:",i);
-					Log.writePure("Class: %x",pSlot->P11Objects[i]->ObjClass);
-					if (Label) {
-						Log.writePure("Label:");
-						info.logParameter(Label->lock(),Label->size());
-					}
-				}
+		pSession->pSlot->dwSessionCount--;
+		if (pSession->pSlot->dwSessionCount == 0) {
+			if (pSession->pSlot->User != CKU_NOBODY) {
+				P11ER_CALL(pSession->Logout(),
+					ERR_CANT_LOGOUT)
 			}
 		}
-	}
-	else {
-		for(DWORD i=0;i<pSlot->P11Objects.size();i++) {
-			auto obj=pSlot->P11Objects[i];
-			CK_OBJECT_HANDLE hObject;
-			bool bSkip=false;
 
-			for (unsigned int j=0;j<ulCount && !bSkip;j++) {
-				ByteArray *attr=NULL;
-				if (obj->getAttribute(pTemplate[j].type,attr)==0) {
-					if (attr) {
-						if (attr->size()!=pTemplate[j].ulValueLen) bSkip=true;
-						else if (memcmp(attr->lock(pTemplate[j].ulValueLen),pTemplate[j].pValue,pTemplate[j].ulValueLen)!=0) bSkip=true;
-					}
-					else bSkip=true;
-				}
-				else bSkip=true;
+		P11ER_CALL(pSession->pSlot->pTemplate->FunctionList.templateFinalSession(pSession->pSlot->pTemplateData),
+			ERR_FINAL_SESSION)
+
+			g_mSessions.erase(hSessionHandle);
+
+		_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	RESULT CSession::GetSessionFromID(CK_SESSION_HANDLE hSessionHandle, std::shared_ptr<CSession>&pSession)
+	{
+		init_func
+			pSession.reset();
+		SessionMap::const_iterator pPair;
+		pPair = g_mSessions.find(hSessionHandle);
+		if (pPair == g_mSessions.end()) {
+			pSession.reset();
+			_return(OK)
+		}
+		pSession = pPair->second;
+		_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	/* ******************* */
+	/*    LOGIN e LOGOUT   */
+	/* ******************* */
+
+	CK_RV CSession::Login(CK_USER_TYPE userType, CK_CHAR_PTR pPin, CK_ULONG ulPinLen)
+	{
+		init_func
+
+			if (pSlot->User == CKU_USER && userType == CKU_SO)
+				_return(CKR_USER_ANOTHER_ALREADY_LOGGED_IN)
+				if (pSlot->User == CKU_SO && userType == CKU_USER)
+					_return(CKR_USER_ANOTHER_ALREADY_LOGGED_IN)
+					bool bExistsRO = false;
+		if (userType == CKU_SO) {
+			P11ER_CALL(ExistsRO(bExistsRO),
+				ERR_RO_SESSION)
+				if (bExistsRO)
+					_return(CKR_SESSION_READ_ONLY_EXISTS)
+		}
+		if (pSlot->User != CKU_NOBODY)
+			_return(CKR_USER_ALREADY_LOGGED_IN)
+
+			ByteArray baPin(pPin, ulPinLen);
+		P11ER_CALL(pSlot->pTemplate->FunctionList.templateLogin(pSlot->pTemplateData, userType, baPin),
+			ERR_CANT_LOGIN)
+
+			pSlot->User = userType;
+
+		_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	CK_RV CSession::Logout() {
+		init_func
+
+			P11ER_CALL(pSlot->pTemplate->FunctionList.templateLogout(pSlot->pTemplateData, pSlot->User),
+			ERR_CANT_LOGOUT)
+
+			for (DWORD i = 0; i<pSlot->P11Objects.size(); i++) {
+				auto p11Obj = pSlot->P11Objects[i];
+				bool bPrivate;
+				P11ER_CALL(p11Obj->IsPrivate(bPrivate),
+					ERR_GET_PRIVATE)
+
+					if (bPrivate)
+						pSlot->DelObjectHandle(p11Obj);
 			}
-			if (!bSkip) {
-			RESULT ris;
-				if (ris=pSlot->GetIDFromObject(pSlot->P11Objects[i],hObject)) {
+		pSlot->User = CKU_NOBODY;
+		_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	/* ******************* */
+	/*    Find Objects     */
+	/* ******************* */
+
+	CK_RV CSession::FindObjectsInit(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount)
+	{
+		init_func
+			if (bFindInit)
+				_return(CKR_OPERATION_ACTIVE)
+				findResult.clear();
+		if (ulCount == 0) {
+			for (DWORD i = 0; i<pSlot->P11Objects.size(); i++) {
+				CK_OBJECT_HANDLE hObject;
+				RESULT ris;
+				if (ris = pSlot->GetIDFromObject(pSlot->P11Objects[i], hObject)) {
 					continue;
 				}
-				findResult.push_back(hObject);
-				if (Log.bLogParam) {
-					ByteArray *Label=NULL;
-					pSlot->P11Objects[i]->getAttribute(CKA_LABEL,Label);
-					Log.writePure("Object found %i:",i);
-					Log.writePure("Class: %x",pSlot->P11Objects[i]->ObjClass);
-					if (Label) {
-						Log.writePure("Label:");
-						info.logParameter(Label->lock(),Label->size());
+				else {
+					findResult.push_back(hObject);
+					if (Log.LogParam) {
+						ByteArray *Label = NULL;
+						pSlot->P11Objects[i]->getAttribute(CKA_LABEL, Label);
+						Log.writePure("Object found %i:", i);
+						Log.writePure("Class: %x", pSlot->P11Objects[i]->ObjClass);
+						if (Label) {
+							Log.writePure("Label:");
+							info.logParameter(Label->data(), Label->size());
+						}
 					}
 				}
 			}
 		}
-	}
-	bFindInit=true;
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
+		else {
+			for (DWORD i = 0; i<pSlot->P11Objects.size(); i++) {
+				auto obj = pSlot->P11Objects[i];
+				CK_OBJECT_HANDLE hObject;
+				bool bSkip = false;
 
-CK_RV CSession::FindObjects(CK_OBJECT_HANDLE_PTR phObject,CK_ULONG ulMaxObjectCount,CK_ULONG_PTR pulObjectCount)
-{
-	init_func
-	if (!bFindInit)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-	*pulObjectCount=0;
-	int iCnt=0;
-	while (!findResult.empty() && ulMaxObjectCount>0) {
-		phObject[iCnt]=findResult.back();
-		findResult.pop_back();
-		iCnt++;
-		ulMaxObjectCount--;
-	}
-	*pulObjectCount=iCnt;
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::FindObjectsFinal()
-{
-	init_func
-	if (!bFindInit)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-	findResult.clear();
-	bFindInit=false;
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::GetAttributeValue(CK_OBJECT_HANDLE hObject, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount )
-{
-	init_func
-
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(hObject,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_OBJECT_HANDLE_INVALID)
-	
-	DWORD ret=pObject->GetAttributeValue(pTemplate,ulCount);
-	_return(ret)
-
-	exit_func
-	_return(FAIL)
-}
-
-RESULT GetTemplateValue(CK_ATTRIBUTE_PTR pTemplate,CK_ULONG ulCount,CK_ATTRIBUTE_TYPE type,ByteDynArray &val)
-{
-	init_func
-	for (unsigned int i=0;i<ulCount;i++) {
-		if (pTemplate[i].type==type) {
-			val.alloc_copy((BYTE *)pTemplate[i].pValue,pTemplate[i].ulValueLen);
-			_return(OK)
+				for (unsigned int j = 0; j<ulCount && !bSkip; j++) {
+					ByteArray *attr = NULL;
+					if (obj->getAttribute(pTemplate[j].type, attr) == 0) {
+						if (attr) {
+							if (attr->size() != pTemplate[j].ulValueLen) bSkip = true;
+							else if (memcmp(attr->data(), pTemplate[j].pValue, pTemplate[j].ulValueLen) != 0) bSkip = true;
+						}
+						else bSkip = true;
+					}
+					else bSkip = true;
+				}
+				if (!bSkip) {
+					RESULT ris;
+					if (ris = pSlot->GetIDFromObject(pSlot->P11Objects[i], hObject)) {
+						continue;
+					}
+					findResult.push_back(hObject);
+					if (Log.LogParam) {
+						ByteArray *Label = NULL;
+						pSlot->P11Objects[i]->getAttribute(CKA_LABEL, Label);
+						Log.writePure("Object found %i:", i);
+						Log.writePure("Class: %x", pSlot->P11Objects[i]->ObjClass);
+						if (Label) {
+							Log.writePure("Label:");
+							info.logParameter(Label->data(), Label->size());
+						}
+					}
+				}
+			}
 		}
+		bFindInit = true;
+		_return(OK)
+			exit_func
+			_return(FAIL)
 	}
-	_return(FAIL)
-	exit_func
-	_return(FAIL)
-}
 
-CK_RV CSession::CreateObject(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount, CK_OBJECT_HANDLE_PTR phObject) {
-	init_func
-
-	if ((flags & CKF_RW_SESSION)==0) 
-		_return(CKR_SESSION_READ_ONLY)
-
-	if (pSlot->User!=CKU_USER) 
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateCreateObject(pSlot->pTemplateData,pTemplate,ulCount,pObject),
-		ERR_CREATE_OBJECT)
-
-	if (pObject!=NULL) {
-		P11ER_CALL(pSlot->GetIDFromObject(pObject,*phObject),
-			ERR_GET_OBJECT_HANDLE)
-	}
-	else 
-		_return(CKR_GENERAL_ERROR)
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::GenerateKey(CK_MECHANISM_PTR pMechanism, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount, CK_OBJECT_HANDLE_PTR phKey) {
-	init_func
-
-	if ((flags & CKF_RW_SESSION)==0) 
-		_return(CKR_SESSION_READ_ONLY)
-
-	if (pSlot->User!=CKU_USER) 
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	std::shared_ptr<CP11Object> pKey;
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateGenerateKey(pSlot->pTemplateData,pMechanism,pTemplate,ulCount,pKey),
-		ERR_CREATE_OBJECT)
-
-	if (pKey!=NULL) {
-		P11ER_CALL(pSlot->GetIDFromObject(pKey,*phKey),
-			ERR_GET_OBJECT_HANDLE)
-	}
-	else 
-		_return(CKR_GENERAL_ERROR)
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::GenerateKeyPair(CK_MECHANISM_PTR pMechanism, CK_ATTRIBUTE_PTR pPublicKeyTemplate, CK_ULONG ulPublicKeyAttributeCount, CK_ATTRIBUTE_PTR pPrivateKeyTemplate, CK_ULONG ulPrivateKeyAttributeCount, CK_OBJECT_HANDLE_PTR phPublicKey, CK_OBJECT_HANDLE_PTR phPrivateKey) {
-	init_func
-
-	if ((flags & CKF_RW_SESSION)==0) 
-		_return(CKR_SESSION_READ_ONLY)
-
-	if (pSlot->User!=CKU_USER) 
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	std::shared_ptr<CP11Object> pPublicKey=NULL;
-	std::shared_ptr<CP11Object> pPrivateKey=NULL;
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateGenerateKeyPair(pSlot->pTemplateData,pMechanism, pPublicKeyTemplate, ulPublicKeyAttributeCount, pPrivateKeyTemplate, ulPrivateKeyAttributeCount, pPublicKey, pPrivateKey),
-		ERR_CREATE_OBJECT)
-
-	if (pPublicKey!=NULL) {
-		P11ER_CALL(pSlot->GetIDFromObject(pPublicKey,*phPublicKey),
-			ERR_GET_OBJECT_HANDLE)
-	}
-	else 
-		_return(CKR_GENERAL_ERROR)
-
-	if (pPrivateKey!=NULL) {
-		P11ER_CALL(pSlot->GetIDFromObject(pPrivateKey,*phPrivateKey),
-			ERR_GET_OBJECT_HANDLE)
-	}
-	else 
-		_return(CKR_GENERAL_ERROR)
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-RESULT CSession::DestroyObject(CK_OBJECT_HANDLE hObject) {
-	init_func
-
-	if ((flags & CKF_RW_SESSION)==0) 
-		_return(CKR_SESSION_READ_ONLY)
-
-	if (pSlot->User!=CKU_USER) 
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(hObject,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_OBJECT_HANDLE_INVALID)
-
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateDestroyObject(pSlot->pTemplateData,*pObject),
-		ERR_CREATE_OBJECT)
-
-	P11ER_CALL(pSlot->DelP11Object(pObject),
-		ERR_CANT_DELETE_OBJECT)
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-RESULT CSession::ExistsRO(bool &bExistsRO)
-{
-	init_func
-	bExistsRO=false;
-	for(SessionMap::const_iterator it=g_mSessions.begin();it!=g_mSessions.end();it++)
+	CK_RV CSession::FindObjects(CK_OBJECT_HANDLE_PTR phObject, CK_ULONG ulMaxObjectCount, CK_ULONG_PTR pulObjectCount)
 	{
-		if (it->second->pSlot==pSlot && (it->second->flags & CKF_RW_SESSION)==0) {
-			bExistsRO=true;
-			_return(OK)
-		}	
+		init_func
+			if (!bFindInit)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+				*pulObjectCount = 0;
+		int iCnt = 0;
+		while (!findResult.empty() && ulMaxObjectCount>0) {
+			phObject[iCnt] = findResult.back();
+			findResult.pop_back();
+			iCnt++;
+			ulMaxObjectCount--;
+		}
+		*pulObjectCount = iCnt;
+		_return(OK)
+			exit_func
+			_return(FAIL)
 	}
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-RESULT CSession::ExistsSO_RW(bool &bExists)
-{
-	init_func
-	bExists=false;
-	if (pSlot->User!=CKU_SO)
-		_return(OK)
-	for(SessionMap::const_iterator it=g_mSessions.begin();it!=g_mSessions.end();it++)
+	CK_RV CSession::FindObjectsFinal()
 	{
-		if (it->second->pSlot==pSlot && (it->second->flags & CKF_RW_SESSION)!=0) {
-			bExists=true;
+		init_func
+			if (!bFindInit)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+				findResult.clear();
+		bFindInit = false;
+		_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	CK_RV CSession::GetAttributeValue(CK_OBJECT_HANDLE hObject, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount)
+	{
+		init_func
+
+			std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(hObject, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_OBJECT_HANDLE_INVALID)
+
+				DWORD ret = pObject->GetAttributeValue(pTemplate, ulCount);
+		_return(ret)
+
+			exit_func
+			_return(FAIL)
+	}
+
+	RESULT GetTemplateValue(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount, CK_ATTRIBUTE_TYPE type, ByteDynArray &val)
+	{
+		init_func
+			for (unsigned int i = 0; i<ulCount; i++) {
+				if (pTemplate[i].type == type) {
+					val= ByteArray((uint8_t*)pTemplate[i].pValue, pTemplate[i].ulValueLen);
+					_return(OK)
+				}
+			}
+		_return(FAIL)
+			exit_func
+			_return(FAIL)
+	}
+
+	CK_RV CSession::CreateObject(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount, CK_OBJECT_HANDLE_PTR phObject) {
+		init_func
+
+			if ((flags & CKF_RW_SESSION) == 0)
+				_return(CKR_SESSION_READ_ONLY)
+
+				if (pSlot->User != CKU_USER)
+					_return(CKR_USER_NOT_LOGGED_IN)
+
+					std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->pTemplate->FunctionList.templateCreateObject(pSlot->pTemplateData, pTemplate, ulCount, pObject),
+			ERR_CREATE_OBJECT)
+
+			if (pObject != NULL) {
+				P11ER_CALL(pSlot->GetIDFromObject(pObject, *phObject),
+					ERR_GET_OBJECT_HANDLE)
+			}
+			else
+				_return(CKR_GENERAL_ERROR)
+
+				_return(OK)
+				exit_func
+				_return(FAIL)
+	}
+
+	CK_RV CSession::GenerateKey(CK_MECHANISM_PTR pMechanism, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount, CK_OBJECT_HANDLE_PTR phKey) {
+		init_func
+
+			if ((flags & CKF_RW_SESSION) == 0)
+				_return(CKR_SESSION_READ_ONLY)
+
+				if (pSlot->User != CKU_USER)
+					_return(CKR_USER_NOT_LOGGED_IN)
+
+					std::shared_ptr<CP11Object> pKey;
+		P11ER_CALL(pSlot->pTemplate->FunctionList.templateGenerateKey(pSlot->pTemplateData, pMechanism, pTemplate, ulCount, pKey),
+			ERR_CREATE_OBJECT)
+
+			if (pKey != NULL) {
+				P11ER_CALL(pSlot->GetIDFromObject(pKey, *phKey),
+					ERR_GET_OBJECT_HANDLE)
+			}
+			else
+				_return(CKR_GENERAL_ERROR)
+
+				_return(OK)
+				exit_func
+				_return(FAIL)
+	}
+
+	CK_RV CSession::GenerateKeyPair(CK_MECHANISM_PTR pMechanism, CK_ATTRIBUTE_PTR pPublicKeyTemplate, CK_ULONG ulPublicKeyAttributeCount, CK_ATTRIBUTE_PTR pPrivateKeyTemplate, CK_ULONG ulPrivateKeyAttributeCount, CK_OBJECT_HANDLE_PTR phPublicKey, CK_OBJECT_HANDLE_PTR phPrivateKey) {
+		init_func
+
+			if ((flags & CKF_RW_SESSION) == 0)
+				_return(CKR_SESSION_READ_ONLY)
+
+				if (pSlot->User != CKU_USER)
+					_return(CKR_USER_NOT_LOGGED_IN)
+
+					std::shared_ptr<CP11Object> pPublicKey = NULL;
+		std::shared_ptr<CP11Object> pPrivateKey = NULL;
+		P11ER_CALL(pSlot->pTemplate->FunctionList.templateGenerateKeyPair(pSlot->pTemplateData, pMechanism, pPublicKeyTemplate, ulPublicKeyAttributeCount, pPrivateKeyTemplate, ulPrivateKeyAttributeCount, pPublicKey, pPrivateKey),
+			ERR_CREATE_OBJECT)
+
+			if (pPublicKey != NULL) {
+				P11ER_CALL(pSlot->GetIDFromObject(pPublicKey, *phPublicKey),
+					ERR_GET_OBJECT_HANDLE)
+			}
+			else
+				_return(CKR_GENERAL_ERROR)
+
+				if (pPrivateKey != NULL) {
+					P11ER_CALL(pSlot->GetIDFromObject(pPrivateKey, *phPrivateKey),
+						ERR_GET_OBJECT_HANDLE)
+				}
+				else
+					_return(CKR_GENERAL_ERROR)
+
+					_return(OK)
+					exit_func
+					_return(FAIL)
+	}
+
+	RESULT CSession::DestroyObject(CK_OBJECT_HANDLE hObject) {
+		init_func
+
+			if ((flags & CKF_RW_SESSION) == 0)
+				_return(CKR_SESSION_READ_ONLY)
+
+				if (pSlot->User != CKU_USER)
+					_return(CKR_USER_NOT_LOGGED_IN)
+
+					std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(hObject, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_OBJECT_HANDLE_INVALID)
+
+				P11ER_CALL(pSlot->pTemplate->FunctionList.templateDestroyObject(pSlot->pTemplateData, *pObject),
+				ERR_CREATE_OBJECT)
+
+				P11ER_CALL(pSlot->DelP11Object(pObject),
+				ERR_CANT_DELETE_OBJECT)
+
+				_return(OK)
+				exit_func
+				_return(FAIL)
+	}
+
+	RESULT CSession::ExistsRO(bool &bExistsRO)
+	{
+		init_func
+			bExistsRO = false;
+		for (SessionMap::const_iterator it = g_mSessions.begin(); it != g_mSessions.end(); it++)
+		{
+			if (it->second->pSlot == pSlot && (it->second->flags & CKF_RW_SESSION) == 0) {
+				bExistsRO = true;
+				_return(OK)
+			}
+		}
+
+		_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	RESULT CSession::ExistsSO_RW(bool &bExists)
+	{
+		init_func
+			bExists = false;
+		if (pSlot->User != CKU_SO)
 			_return(OK)
-		}	
-	}
+			for (SessionMap::const_iterator it = g_mSessions.begin(); it != g_mSessions.end(); it++)
+			{
+				if (it->second->pSlot == pSlot && (it->second->flags & CKF_RW_SESSION) != 0) {
+					bExists = true;
+					_return(OK)
+				}
+			}
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-/* ******************* */
-/*       Digest        */
-/* ******************* */
-
-CK_RV CSession::DigestInit(CK_MECHANISM_PTR pMechanism)
-{
-	init_func	
-	if (pDigestMechanism)
-		_return(CKR_OPERATION_ACTIVE)
-
-	switch (pMechanism->mechanism) {
-		case CKM_SHA_1:
-		{
-			auto mech = std::unique_ptr<CSHA>(new CSHA(shared_from_this()));
-			P11ER_CALL(mech->DigestInit(),
-				ERR_CANT_INITIALIZE_MECHANISM)
-
-			pDigestMechanism=std::move(mech);
-			break;
-		}
-		case CKM_MD5:
-		{
-			auto mech = std::unique_ptr<CMD5>(new CMD5(shared_from_this()));
-			P11ER_CALL(mech->DigestInit(),
-				ERR_CANT_INITIALIZE_MECHANISM)
-
-			pDigestMechanism=std::move(mech);
-			break;
-		}
-		default:
-			_return(CKR_MECHANISM_INVALID)
-	}
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::Digest(ByteArray &Data, ByteArray &Digest)
-{
-	init_func
-
-	CK_ULONG ulReqLen=0;
-	P11ER_CALL(pDigestMechanism->DigestLength(&ulReqLen),
-		ERR_CANT_GET_MECHANISM_LENGTH)
-
-	if (!Digest.isNull() && Digest.size()<ulReqLen)
-		_return(CKR_BUFFER_TOO_SMALL)
-
-	Digest.dwSize=ulReqLen;
-	if (Digest.isNull())
 		_return(OK)
-
-	CK_RV result=DigestUpdate(Data);
-	if (result!=OK)
-		_return(result)
-
-	DWORD ret=DigestFinal(Digest);
-	_return(ret)
-
-	exit_func
-	_return(FAIL)
-		
-}
-
-CK_RV CSession::DigestUpdate(ByteArray &Data)
-{
-	init_func	
-	if (!pDigestMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	P11ER_CALL(pDigestMechanism->DigestUpdate(Data),
-		ERR_CANT_UPDATE_MECHANISM)
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-		
-}
-
-CK_RV CSession::DigestFinal(ByteArray &Digest)
-{
-	init_func	
-	if (!pDigestMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	auto mech = std::move(pDigestMechanism);
-	CK_ULONG ulReqLen=0;
-	P11ER_CALL(pDigestMechanism->DigestLength(&ulReqLen),
-		ERR_CANT_GET_MECHANISM_LENGTH)
-
-	if (!Digest.isNull() && Digest.size()<ulReqLen) {
-		pDigestMechanism = std::move(mech);
-		_return(CKR_BUFFER_TOO_SMALL)
+			exit_func
+			_return(FAIL)
 	}
 
-	Digest.dwSize=ulReqLen;
-	if (Digest.isNull()) {
-		pDigestMechanism = std::move(mech);
+	/* ******************* */
+	/*       Digest        */
+	/* ******************* */
+
+	CK_RV CSession::DigestInit(CK_MECHANISM_PTR pMechanism)
+	{
+		init_func
+			if (pDigestMechanism)
+				_return(CKR_OPERATION_ACTIVE)
+
+				switch (pMechanism->mechanism) {
+				case CKM_SHA_1:
+				{
+					auto mech = std::unique_ptr<CSHA>(new CSHA(shared_from_this()));
+					P11ER_CALL(mech->DigestInit(),
+						ERR_CANT_INITIALIZE_MECHANISM)
+
+						pDigestMechanism = std::move(mech);
+					break;
+				}
+				case CKM_MD5:
+				{
+					auto mech = std::unique_ptr<CMD5>(new CMD5(shared_from_this()));
+					P11ER_CALL(mech->DigestInit(),
+						ERR_CANT_INITIALIZE_MECHANISM)
+
+						pDigestMechanism = std::move(mech);
+					break;
+				}
+				default:
+					_return(CKR_MECHANISM_INVALID)
+			}
+
 		_return(OK)
-	}
-		
-	RESULT ris;
-	if (ris=pDigestMechanism->DigestFinal(Digest))
-		_return(ris)
-	
-	_return(OK)
-
-	exit_func
-	_return(FAIL)
-		
-}
-
-/* ******************* */
-/*       Verify        */
-/* ******************* */
-
-CK_RV CSession::VerifyInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
-{
-	init_func
-	if (pVerifyMechanism)
-		_return(CKR_OPERATION_ACTIVE)
-
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(hKey,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_KEY_HANDLE_INVALID)
-	if (pObject->ObjClass!=CKO_PUBLIC_KEY)
-		_return(CKR_KEY_HANDLE_INVALID)
-	auto pVerifyKey=std::static_pointer_cast<CP11PublicKey>(pObject);
-	
-	bool bPrivate=false;
-	P11ER_CALL(pVerifyKey->IsPrivate(bPrivate),
-		ERR_GET_PRIVATE)
-
-	if (bPrivate && pSlot->User!=CKU_USER)
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	ByteArray *baAttrVal=NULL;
-	P11ER_CALL(pVerifyKey->getAttribute(CKA_VERIFY,baAttrVal),
-		ERR_GET_ATTRIBUTE)
-	if (baAttrVal==NULL)
-		_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
-	else {
-		if (ByteArrayToVar(*baAttrVal,CK_BBOOL)==FALSE)
-			_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			exit_func
+			_return(FAIL)
 	}
 
-	switch (pMechanism->mechanism) {
+	CK_RV CSession::Digest(ByteArray &Data, ByteArray &Digest)
+	{
+		init_func
+
+		CK_ULONG ulReqLen = 0;
+		P11ER_CALL(pDigestMechanism->DigestLength(&ulReqLen),
+			ERR_CANT_GET_MECHANISM_LENGTH)
+
+		if (!Digest.isNull() && Digest.size() < ulReqLen)
+			_return(CKR_BUFFER_TOO_SMALL)
+
+		Digest = Digest.left(ulReqLen);
+		if (Digest.isNull())
+			_return(OK)
+
+		CK_RV result = DigestUpdate(Data);
+		if (result != OK)
+			_return(result)
+
+			DWORD ret = DigestFinal(Digest);
+		_return(ret)
+
+			exit_func
+			_return(FAIL)
+
+	}
+
+	CK_RV CSession::DigestUpdate(ByteArray &Data)
+	{
+		init_func
+			if (!pDigestMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+
+				P11ER_CALL(pDigestMechanism->DigestUpdate(Data),
+				ERR_CANT_UPDATE_MECHANISM)
+
+				_return(OK)
+				exit_func
+				_return(FAIL)
+
+	}
+
+	CK_RV CSession::DigestFinal(ByteArray &Digest)
+	{
+		init_func
+			if (!pDigestMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+
+				auto mech = std::move(pDigestMechanism);
+		CK_ULONG ulReqLen = 0;
+		P11ER_CALL(pDigestMechanism->DigestLength(&ulReqLen),
+			ERR_CANT_GET_MECHANISM_LENGTH)
+
+			if (!Digest.isNull() && Digest.size()<ulReqLen) {
+				pDigestMechanism = std::move(mech);
+				_return(CKR_BUFFER_TOO_SMALL)
+			}
+
+		Digest = Digest.left(ulReqLen);
+		if (Digest.isNull()) {
+			pDigestMechanism = std::move(mech);
+			_return(OK)
+		}
+
+		RESULT ris;
+		if (ris = pDigestMechanism->DigestFinal(Digest))
+			_return(ris)
+
+			_return(OK)
+
+			exit_func
+			_return(FAIL)
+
+	}
+
+	/* ******************* */
+	/*       Verify        */
+	/* ******************* */
+
+	CK_RV CSession::VerifyInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
+	{
+		init_func
+			if (pVerifyMechanism)
+				_return(CKR_OPERATION_ACTIVE)
+
+				std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(hKey, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_KEY_HANDLE_INVALID)
+				if (pObject->ObjClass != CKO_PUBLIC_KEY)
+					_return(CKR_KEY_HANDLE_INVALID)
+					auto pVerifyKey = std::static_pointer_cast<CP11PublicKey>(pObject);
+
+		bool bPrivate = false;
+		P11ER_CALL(pVerifyKey->IsPrivate(bPrivate),
+			ERR_GET_PRIVATE)
+
+			if (bPrivate && pSlot->User != CKU_USER)
+				_return(CKR_USER_NOT_LOGGED_IN)
+
+				ByteArray *baAttrVal = NULL;
+		P11ER_CALL(pVerifyKey->getAttribute(CKA_VERIFY, baAttrVal),
+			ERR_GET_ATTRIBUTE)
+			if (baAttrVal == NULL)
+				_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			else {
+				if (ByteArrayToVar(*baAttrVal, CK_BBOOL) == FALSE)
+					_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			}
+
+		switch (pMechanism->mechanism) {
 		case CKM_SHA1_RSA_PKCS:
 		{
 			auto mech = std::unique_ptr<CRSAwithSHA1>(new CRSAwithSHA1(shared_from_this()));
 			P11ER_CALL(mech->VerifyInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pVerifyMechanism=std::move(mech);
+				pVerifyMechanism = std::move(mech);
 			break;
 		}
 		case CKM_MD5_RSA_PKCS:
@@ -643,7 +647,7 @@ CK_RV CSession::VerifyInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 			auto mech = std::unique_ptr<CRSAwithMD5>(new CRSAwithMD5(shared_from_this()));
 			P11ER_CALL(mech->VerifyInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pVerifyMechanism=std::move(mech);
+				pVerifyMechanism = std::move(mech);
 			break;
 		}
 		case CKM_RSA_PKCS:
@@ -651,7 +655,7 @@ CK_RV CSession::VerifyInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 			auto mech = std::unique_ptr<CRSA_PKCS1>(new CRSA_PKCS1(shared_from_this()));
 			P11ER_CALL(mech->VerifyInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pVerifyMechanism=std::move(mech);
+				pVerifyMechanism = std::move(mech);
 			break;
 		}
 		case CKM_RSA_X_509:
@@ -659,205 +663,205 @@ CK_RV CSession::VerifyInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 			auto mech = std::unique_ptr<CRSA_X509>(new CRSA_X509(shared_from_this()));
 			P11ER_CALL(mech->VerifyInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pVerifyMechanism=std::move(mech);
+				pVerifyMechanism = std::move(mech);
 			break;
 		}
 		default:
 			_return(CKR_MECHANISM_INVALID)
-	}
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::Verify(ByteArray &Data, ByteArray &Signature)
-{
-	init_func
-
-	if (!pVerifyMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	CK_RV result=VerifyUpdate(Data);
-	if (result!=OK)
-		_return(result)
-
-	DWORD ret=VerifyFinal(Signature);
-	_return(ret)
-
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::VerifyUpdate(ByteArray &Data)
-{
-	init_func
-	if (!pVerifyMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	P11ER_CALL(pVerifyMechanism->VerifyUpdate(Data),
-		ERR_CANT_UPDATE_MECHANISM)
-	_return(OK)
-
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::VerifyFinal(ByteArray &Signature)
-{
-	init_func
-	if (!pVerifyMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	auto mech = make_resetter(pVerifyMechanism);
-	P11ER_CALL(pVerifyMechanism->VerifyFinal(Signature),
-		ERR_CANT_FINAL_MECHANISM)
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-/* ******************** */
-/*		VerifyRecover	*/
-/* ******************** */
-
-CK_RV CSession::VerifyRecoverInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
-{
-	init_func
-	if (pVerifyRecoverMechanism)
-		_return(CKR_OPERATION_ACTIVE)
-
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(hKey,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_KEY_HANDLE_INVALID)
-	if (pObject->ObjClass!=CKO_PUBLIC_KEY)
-		_return(CKR_KEY_HANDLE_INVALID)
-	auto pVerifyRecoverKey=std::static_pointer_cast<CP11PublicKey>(pObject);
-	
-	bool bPrivate=false;
-	P11ER_CALL(pVerifyRecoverKey->IsPrivate(bPrivate),
-		ERR_GET_PRIVATE)
-
-	if (bPrivate && pSlot->User!=CKU_USER)
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	ByteArray *baAttrVal=NULL;
-	P11ER_CALL(pVerifyRecoverKey->getAttribute(CKA_VERIFY_RECOVER,baAttrVal),
-		ERR_GET_ATTRIBUTE)
-	if (baAttrVal==NULL)
-		_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
-	else {
-		if (ByteArrayToVar(*baAttrVal,CK_BBOOL)==FALSE)
-			_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
-	}
-
-	switch (pMechanism->mechanism) {
-		case CKM_RSA_PKCS:
-		{
-			auto mech = std::unique_ptr<CRSA_PKCS1>(new CRSA_PKCS1(shared_from_this()));
-			P11ER_CALL(mech->VerifyRecoverInit(hKey),
-				ERR_CANT_INITIALIZE_MECHANISM)
-			pVerifyRecoverMechanism=std::move(mech);
-			break;
 		}
-		case CKM_RSA_X_509:
-		{
-			auto mech = std::unique_ptr<CRSA_X509>(new CRSA_X509(shared_from_this()));
-			P11ER_CALL(mech->VerifyRecoverInit(hKey),
-				ERR_CANT_INITIALIZE_MECHANISM)
-			pVerifyRecoverMechanism=std::move(mech);
-			break;
-		}
-		default:
-			_return(CKR_MECHANISM_INVALID)
-	}
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::VerifyRecover(ByteArray &Signature,ByteArray &Data)
-{
-	init_func
-	if (!pVerifyRecoverMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	auto mech = std::move(pVerifyRecoverMechanism);
-
-	CK_ULONG ulKeyLen=0;
-	P11ER_CALL(pVerifyRecoverMechanism->VerifyRecoverLength(&ulKeyLen),
-		ERR_CANT_GET_MECHANISM_LENGTH)
-
-	ByteDynArray baData(ulKeyLen);
-	P11ER_CALL(pVerifyRecoverMechanism->VerifyRecover(Signature,baData),
-		ERR_CANT_FINAL_MECHANISM)
-
-	if (!Data.isNull() && Data.size()<baData.size()) {
-		pVerifyRecoverMechanism = std::move(mech);
-		_return(CKR_BUFFER_TOO_SMALL)
-	}
-
-	Data.dwSize=baData.size();
-	if (Data.isNull()) {
-		pVerifyRecoverMechanism = std::move(mech);
 		_return(OK)
+			exit_func
+			_return(FAIL)
 	}
 
+	CK_RV CSession::Verify(ByteArray &Data, ByteArray &Signature)
+	{
+		init_func
 
-	Data.copy(baData);
+			if (!pVerifyMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
+				CK_RV result = VerifyUpdate(Data);
+		if (result != OK)
+			_return(result)
 
-/* ******************* */
-/*       Sign          */
-/* ******************* */
+			DWORD ret = VerifyFinal(Signature);
+		_return(ret)
 
-CK_RV CSession::SignInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
-{
-	init_func
-	if (pSignMechanism)
-		_return(CKR_OPERATION_ACTIVE)
-
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(hKey,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_KEY_HANDLE_INVALID)
-	if (pObject->ObjClass!=CKO_PRIVATE_KEY)
-		_return(CKR_KEY_HANDLE_INVALID)
-	auto pSignKey= std::static_pointer_cast<CP11PrivateKey>(pObject);
-	
-	bool bPrivate=false;
-	P11ER_CALL(pSignKey->IsPrivate(bPrivate),
-		ERR_GET_PRIVATE)
-
-	if (bPrivate && pSlot->User!=CKU_USER)
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	ByteArray *baAttrVal=NULL;
-	P11ER_CALL(pSignKey->getAttribute(CKA_SIGN,baAttrVal),
-		ERR_GET_ATTRIBUTE)
-	if (baAttrVal==NULL)
-		_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
-	else {
-		if (ByteArrayToVar(*baAttrVal,CK_BBOOL)==FALSE)
-			_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			exit_func
+			_return(FAIL)
 	}
 
-	switch (pMechanism->mechanism) {
+	CK_RV CSession::VerifyUpdate(ByteArray &Data)
+	{
+		init_func
+			if (!pVerifyMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+
+				P11ER_CALL(pVerifyMechanism->VerifyUpdate(Data),
+				ERR_CANT_UPDATE_MECHANISM)
+				_return(OK)
+
+				exit_func
+				_return(FAIL)
+	}
+
+	CK_RV CSession::VerifyFinal(ByteArray &Signature)
+	{
+		init_func
+			if (!pVerifyMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+
+				auto mech = make_resetter(pVerifyMechanism);
+		P11ER_CALL(pVerifyMechanism->VerifyFinal(Signature),
+			ERR_CANT_FINAL_MECHANISM)
+
+			_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	/* ******************** */
+	/*		VerifyRecover	*/
+	/* ******************** */
+
+	CK_RV CSession::VerifyRecoverInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
+	{
+		init_func
+			if (pVerifyRecoverMechanism)
+				_return(CKR_OPERATION_ACTIVE)
+
+				std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(hKey, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_KEY_HANDLE_INVALID)
+				if (pObject->ObjClass != CKO_PUBLIC_KEY)
+					_return(CKR_KEY_HANDLE_INVALID)
+					auto pVerifyRecoverKey = std::static_pointer_cast<CP11PublicKey>(pObject);
+
+		bool bPrivate = false;
+		P11ER_CALL(pVerifyRecoverKey->IsPrivate(bPrivate),
+			ERR_GET_PRIVATE)
+
+			if (bPrivate && pSlot->User != CKU_USER)
+				_return(CKR_USER_NOT_LOGGED_IN)
+
+				ByteArray *baAttrVal = NULL;
+		P11ER_CALL(pVerifyRecoverKey->getAttribute(CKA_VERIFY_RECOVER, baAttrVal),
+			ERR_GET_ATTRIBUTE)
+			if (baAttrVal == NULL)
+				_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			else {
+				if (ByteArrayToVar(*baAttrVal, CK_BBOOL) == FALSE)
+					_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			}
+
+		switch (pMechanism->mechanism) {
+		case CKM_RSA_PKCS:
+		{
+			auto mech = std::unique_ptr<CRSA_PKCS1>(new CRSA_PKCS1(shared_from_this()));
+			P11ER_CALL(mech->VerifyRecoverInit(hKey),
+				ERR_CANT_INITIALIZE_MECHANISM)
+				pVerifyRecoverMechanism = std::move(mech);
+			break;
+		}
+		case CKM_RSA_X_509:
+		{
+			auto mech = std::unique_ptr<CRSA_X509>(new CRSA_X509(shared_from_this()));
+			P11ER_CALL(mech->VerifyRecoverInit(hKey),
+				ERR_CANT_INITIALIZE_MECHANISM)
+				pVerifyRecoverMechanism = std::move(mech);
+			break;
+		}
+		default:
+			_return(CKR_MECHANISM_INVALID)
+		}
+
+		_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	CK_RV CSession::VerifyRecover(ByteArray &Signature, ByteArray &Data)
+	{
+		init_func
+			if (!pVerifyRecoverMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+
+				auto mech = std::move(pVerifyRecoverMechanism);
+
+		CK_ULONG ulKeyLen = 0;
+		P11ER_CALL(pVerifyRecoverMechanism->VerifyRecoverLength(&ulKeyLen),
+			ERR_CANT_GET_MECHANISM_LENGTH)
+
+			ByteDynArray baData(ulKeyLen);
+		P11ER_CALL(pVerifyRecoverMechanism->VerifyRecover(Signature, baData),
+			ERR_CANT_FINAL_MECHANISM)
+
+			if (!Data.isNull() && Data.size()<baData.size()) {
+				pVerifyRecoverMechanism = std::move(mech);
+				_return(CKR_BUFFER_TOO_SMALL)
+			}
+
+		Data = Data.left(baData.size());
+		if (Data.isNull()) {
+			pVerifyRecoverMechanism = std::move(mech);
+			_return(OK)
+		}
+
+
+		Data.copy(baData);
+
+		_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	/* ******************* */
+	/*       Sign          */
+	/* ******************* */
+
+	CK_RV CSession::SignInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
+	{
+		init_func
+			if (pSignMechanism)
+				_return(CKR_OPERATION_ACTIVE)
+
+				std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(hKey, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_KEY_HANDLE_INVALID)
+				if (pObject->ObjClass != CKO_PRIVATE_KEY)
+					_return(CKR_KEY_HANDLE_INVALID)
+					auto pSignKey = std::static_pointer_cast<CP11PrivateKey>(pObject);
+
+		bool bPrivate = false;
+		P11ER_CALL(pSignKey->IsPrivate(bPrivate),
+			ERR_GET_PRIVATE)
+
+			if (bPrivate && pSlot->User != CKU_USER)
+				_return(CKR_USER_NOT_LOGGED_IN)
+
+				ByteArray *baAttrVal = NULL;
+		P11ER_CALL(pSignKey->getAttribute(CKA_SIGN, baAttrVal),
+			ERR_GET_ATTRIBUTE)
+			if (baAttrVal == NULL)
+				_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			else {
+				if (ByteArrayToVar(*baAttrVal, CK_BBOOL) == FALSE)
+					_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			}
+
+		switch (pMechanism->mechanism) {
 		case CKM_SHA1_RSA_PKCS:
 		{
 			auto mech = std::unique_ptr<CRSAwithSHA1>(new CRSAwithSHA1(shared_from_this()));
 			P11ER_CALL(mech->SignInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pSignMechanism=std::move(mech);
+				pSignMechanism = std::move(mech);
 			break;
 		}
 		case CKM_MD5_RSA_PKCS:
@@ -865,7 +869,7 @@ CK_RV CSession::SignInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 			auto mech = std::unique_ptr<CRSAwithMD5>(new CRSAwithMD5(shared_from_this()));
 			P11ER_CALL(mech->SignInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pSignMechanism=std::move(mech);
+				pSignMechanism = std::move(mech);
 			break;
 		}
 		case CKM_RSA_PKCS:
@@ -873,278 +877,278 @@ CK_RV CSession::SignInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 			auto mech = std::unique_ptr<CRSA_PKCS1>(new CRSA_PKCS1(shared_from_this()));
 			P11ER_CALL(mech->SignInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pSignMechanism=std::move(mech);
+				pSignMechanism = std::move(mech);
 			break;
 		}
 		case CKM_RSA_X_509:
 		{
 			auto mech = std::unique_ptr<CRSA_X509>(new CRSA_X509(shared_from_this()));
-			P11ER_CALL(mech->SignInit(hKey),ERR_CANT_INITIALIZE_MECHANISM)
-			pSignMechanism=std::move(mech);
+			P11ER_CALL(mech->SignInit(hKey), ERR_CANT_INITIALIZE_MECHANISM)
+				pSignMechanism = std::move(mech);
 			break;
 		}
 		default:
 			_return(CKR_MECHANISM_INVALID)
-	}
+		}
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::Sign(ByteArray &Data, ByteArray &Signature)
-{
-	init_func
-	if (!pSignMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	bool bFound=false;
-	CK_RV result=pSignMechanism->SignReset();
-	if (result!=OK)
-		_return(result)
-
-	result=SignUpdate(Data);
-	if (result!=OK)
-		_return(result)
-
-	DWORD ret=SignFinal(Signature);
-
-	_return(ret)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::SignUpdate(ByteArray &Data)
-{
-	init_func
-	if (!pSignMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	DWORD ret=pSignMechanism->SignUpdate(Data);
-	_return(ret)
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::SignFinal(ByteArray &Signature)
-{
-	init_func
-	if (!pSignMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	auto mech = make_resetter(pSignMechanism);
-
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(pSignMechanism->hSignKey,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_KEY_HANDLE_INVALID)
-	if (pObject->ObjClass!=CKO_PRIVATE_KEY)
-		_return(CKR_KEY_HANDLE_INVALID)
-	auto pSignKey= std::static_pointer_cast<CP11PrivateKey>(pObject);
-
-	bool bPrivate=false;
-	P11ER_CALL(pSignKey->IsPrivate(bPrivate),
-		ERR_GET_PRIVATE)
-
-	if (bPrivate && pSlot->User!=CKU_USER)
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	if (Signature.isNull()) {
-		CK_ULONG ulSignLength;
-		P11ER_CALL(pSignMechanism->SignLength(&ulSignLength),
-			ERR_CANT_GET_PRIVKEY_LENGTH)
-		Signature.dwSize=ulSignLength;
-		mech.release();
 		_return(OK)
+			exit_func
+			_return(FAIL)
 	}
 
-	ByteDynArray baSignBuffer;
-	RESULT ris;
-	if (ris=pSignMechanism->SignFinal(baSignBuffer))
-		_return(ris)
-	
-	bool bSilent = false;
-	ByteDynArray baSignature;
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateSign(pSlot->pTemplateData,pSignKey.get(),baSignBuffer,baSignature,pSignMechanism->mtType,bSilent),
-		ERR_CANT_SIGN)
-	
-	if (Signature.size()<baSignature.size()) {
-		Signature.dwSize=baSignature.size();
-		mech.release();
-		_return(CKR_BUFFER_TOO_SMALL)
-	}
-	else {
-		Signature.copy(baSignature);
-		Signature.dwSize=baSignature.size();
-	}
+	CK_RV CSession::Sign(ByteArray &Data, ByteArray &Signature)
+	{
+		init_func
+			if (!pSignMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
+				bool bFound = false;
+		CK_RV result = pSignMechanism->SignReset();
+		if (result != OK)
+			_return(result)
 
-/* ******************* */
-/*       SignRecover   */
-/* ******************* */
+			result = SignUpdate(Data);
+		if (result != OK)
+			_return(result)
 
-CK_RV CSession::SignRecoverInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
-{
-	init_func
-	if (pSignRecoverMechanism)
-		_return(CKR_OPERATION_ACTIVE)
+			DWORD ret = SignFinal(Signature);
 
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(hKey,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_KEY_HANDLE_INVALID)
-	if (pObject->ObjClass!=CKO_PRIVATE_KEY)
-		_return(CKR_KEY_HANDLE_INVALID)
-	auto pSignRecoverKey=std::static_pointer_cast<CP11PrivateKey>(pObject);
-	
-	bool bPrivate=false;
-	P11ER_CALL(pSignRecoverKey->IsPrivate(bPrivate),
-		ERR_GET_PRIVATE)
-
-	if (bPrivate && pSlot->User!=CKU_USER)
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	ByteArray *baAttrVal=NULL;
-	P11ER_CALL(pSignRecoverKey->getAttribute(CKA_SIGN_RECOVER,baAttrVal),
-		ERR_GET_ATTRIBUTE)
-	if (baAttrVal==NULL)
-		_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
-	else {
-		if (ByteArrayToVar(*baAttrVal,CK_BBOOL)==FALSE)
-			_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+		_return(ret)
+			exit_func
+			_return(FAIL)
 	}
 
-	switch (pMechanism->mechanism) {
+	CK_RV CSession::SignUpdate(ByteArray &Data)
+	{
+		init_func
+			if (!pSignMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+
+				DWORD ret = pSignMechanism->SignUpdate(Data);
+		_return(ret)
+
+			_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	CK_RV CSession::SignFinal(ByteArray &Signature)
+	{
+		init_func
+			if (!pSignMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+
+				auto mech = make_resetter(pSignMechanism);
+
+		std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(pSignMechanism->hSignKey, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_KEY_HANDLE_INVALID)
+				if (pObject->ObjClass != CKO_PRIVATE_KEY)
+					_return(CKR_KEY_HANDLE_INVALID)
+					auto pSignKey = std::static_pointer_cast<CP11PrivateKey>(pObject);
+
+		bool bPrivate = false;
+		P11ER_CALL(pSignKey->IsPrivate(bPrivate),
+			ERR_GET_PRIVATE)
+
+			if (bPrivate && pSlot->User != CKU_USER)
+				_return(CKR_USER_NOT_LOGGED_IN)
+
+				if (Signature.isNull()) {
+					CK_ULONG ulSignLength;
+					P11ER_CALL(pSignMechanism->SignLength(&ulSignLength),
+						ERR_CANT_GET_PRIVKEY_LENGTH)
+						Signature = Signature.left(ulSignLength);
+					mech.release();
+					_return(OK)
+				}
+
+		ByteDynArray baSignBuffer;
+		RESULT ris;
+		if (ris = pSignMechanism->SignFinal(baSignBuffer))
+			_return(ris)
+
+			bool bSilent = false;
+		ByteDynArray baSignature;
+		P11ER_CALL(pSlot->pTemplate->FunctionList.templateSign(pSlot->pTemplateData, pSignKey.get(), baSignBuffer, baSignature, pSignMechanism->mtType, bSilent),
+			ERR_CANT_SIGN)
+
+			if (Signature.size()<baSignature.size()) {
+				Signature = Signature.left(baSignature.size());
+				mech.release();
+				_return(CKR_BUFFER_TOO_SMALL)
+			}
+			else {
+				Signature.copy(baSignature);
+				Signature = Signature.left(baSignature.size());
+			}
+
+			_return(OK)
+				exit_func
+				_return(FAIL)
+	}
+
+	/* ******************* */
+	/*       SignRecover   */
+	/* ******************* */
+
+	CK_RV CSession::SignRecoverInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
+	{
+		init_func
+			if (pSignRecoverMechanism)
+				_return(CKR_OPERATION_ACTIVE)
+
+				std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(hKey, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_KEY_HANDLE_INVALID)
+				if (pObject->ObjClass != CKO_PRIVATE_KEY)
+					_return(CKR_KEY_HANDLE_INVALID)
+					auto pSignRecoverKey = std::static_pointer_cast<CP11PrivateKey>(pObject);
+
+		bool bPrivate = false;
+		P11ER_CALL(pSignRecoverKey->IsPrivate(bPrivate),
+			ERR_GET_PRIVATE)
+
+			if (bPrivate && pSlot->User != CKU_USER)
+				_return(CKR_USER_NOT_LOGGED_IN)
+
+				ByteArray *baAttrVal = NULL;
+		P11ER_CALL(pSignRecoverKey->getAttribute(CKA_SIGN_RECOVER, baAttrVal),
+			ERR_GET_ATTRIBUTE)
+			if (baAttrVal == NULL)
+				_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			else {
+				if (ByteArrayToVar(*baAttrVal, CK_BBOOL) == FALSE)
+					_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			}
+
+		switch (pMechanism->mechanism) {
 		case CKM_RSA_PKCS:
 		{
 			auto mech = std::unique_ptr<CRSA_PKCS1>(new CRSA_PKCS1(shared_from_this()));
 			P11ER_CALL(mech->SignRecoverInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pSignRecoverMechanism=std::move(mech);
+				pSignRecoverMechanism = std::move(mech);
 			break;
 		}
 		case CKM_RSA_X_509:
 		{
 			auto mech = std::unique_ptr<CRSA_X509>(new CRSA_X509(shared_from_this()));
-			P11ER_CALL(mech->SignRecoverInit(hKey),ERR_CANT_INITIALIZE_MECHANISM)
-			pSignRecoverMechanism=std::move(mech);
+			P11ER_CALL(mech->SignRecoverInit(hKey), ERR_CANT_INITIALIZE_MECHANISM)
+				pSignRecoverMechanism = std::move(mech);
 			break;
 		}
 		default:
 			_return(CKR_MECHANISM_INVALID)
-	}
+		}
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::SignRecover(ByteArray &Data, ByteArray &Signature)
-{
-	init_func
-	if (!pSignRecoverMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	auto mech = make_resetter(pSignRecoverMechanism);
-
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(pSignRecoverMechanism->hSignRecoverKey,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_KEY_HANDLE_INVALID)
-	if (pObject->ObjClass!=CKO_PRIVATE_KEY)
-		_return(CKR_KEY_HANDLE_INVALID)
-	auto pSignRecoverKey=std::static_pointer_cast<CP11PrivateKey>(pObject);
-
-	bool bPrivate=false;
-	P11ER_CALL(pSignRecoverKey->IsPrivate(bPrivate),
-		ERR_GET_PRIVATE)
-
-	if (bPrivate && pSlot->User!=CKU_USER)
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	if (Signature.isNull()) {
-		CK_ULONG ulSignRecoverLength;
-		P11ER_CALL(pSignRecoverMechanism->SignRecoverLength(&ulSignRecoverLength),
-			ERR_CANT_GET_PRIVKEY_LENGTH)
-		Signature.dwSize=ulSignRecoverLength;
-		mech.release();
 		_return(OK)
+			exit_func
+			_return(FAIL)
 	}
 
-	ByteDynArray baSignRecoverBuffer;
-	RESULT ris;
-	if (ris=pSignRecoverMechanism->SignRecover(Data,baSignRecoverBuffer))
-		_return(ris)
-	
-	bool bSilent=false;
+	CK_RV CSession::SignRecover(ByteArray &Data, ByteArray &Signature)
+	{
+		init_func
+			if (!pSignRecoverMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
 
-	ByteDynArray baSignature;
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateSignRecover(pSlot->pTemplateData,pSignRecoverKey.get(),baSignRecoverBuffer,baSignature,pSignRecoverMechanism->mtType,bSilent),
-		ERR_CANT_SIGN)
+				auto mech = make_resetter(pSignRecoverMechanism);
 
-if (Signature.size()<baSignature.size()) {
-		Signature.dwSize=baSignature.size();
-		mech.release();
-		_return(CKR_BUFFER_TOO_SMALL)
+		std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(pSignRecoverMechanism->hSignRecoverKey, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_KEY_HANDLE_INVALID)
+				if (pObject->ObjClass != CKO_PRIVATE_KEY)
+					_return(CKR_KEY_HANDLE_INVALID)
+					auto pSignRecoverKey = std::static_pointer_cast<CP11PrivateKey>(pObject);
+
+		bool bPrivate = false;
+		P11ER_CALL(pSignRecoverKey->IsPrivate(bPrivate),
+			ERR_GET_PRIVATE)
+
+			if (bPrivate && pSlot->User != CKU_USER)
+				_return(CKR_USER_NOT_LOGGED_IN)
+
+				if (Signature.isNull()) {
+					CK_ULONG ulSignRecoverLength;
+					P11ER_CALL(pSignRecoverMechanism->SignRecoverLength(&ulSignRecoverLength),
+						ERR_CANT_GET_PRIVKEY_LENGTH)
+						Signature = Signature.left(ulSignRecoverLength);
+					mech.release();
+					_return(OK)
+				}
+
+		ByteDynArray baSignRecoverBuffer;
+		RESULT ris;
+		if (ris = pSignRecoverMechanism->SignRecover(Data, baSignRecoverBuffer))
+			_return(ris)
+
+			bool bSilent = false;
+
+		ByteDynArray baSignature;
+		P11ER_CALL(pSlot->pTemplate->FunctionList.templateSignRecover(pSlot->pTemplateData, pSignRecoverKey.get(), baSignRecoverBuffer, baSignature, pSignRecoverMechanism->mtType, bSilent),
+			ERR_CANT_SIGN)
+
+			if (Signature.size()<baSignature.size()) {
+				Signature = Signature.left(baSignature.size());
+				mech.release();
+				_return(CKR_BUFFER_TOO_SMALL)
+			}
+
+		_return(OK)
+			exit_func
+			_return(FAIL)
 	}
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
+	/* ******************* */
+	/*       Encrypt        */
+	/* ******************* */
 
-/* ******************* */
-/*       Encrypt        */
-/* ******************* */
+	CK_RV CSession::EncryptInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
+	{
+		init_func
+			if (pEncryptMechanism)
+				_return(CKR_OPERATION_ACTIVE)
 
-CK_RV CSession::EncryptInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
-{
-	init_func
-	if (pEncryptMechanism)
-		_return(CKR_OPERATION_ACTIVE)
+				std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(hKey, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_KEY_HANDLE_INVALID)
+				if (pObject->ObjClass != CKO_PUBLIC_KEY)
+					_return(CKR_KEY_HANDLE_INVALID)
+					auto pEncryptKey = std::static_pointer_cast<CP11PublicKey>(pObject);
 
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(hKey,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_KEY_HANDLE_INVALID)
-	if (pObject->ObjClass!=CKO_PUBLIC_KEY)
-		_return(CKR_KEY_HANDLE_INVALID)
-	auto pEncryptKey= std::static_pointer_cast<CP11PublicKey>(pObject);
-	
-	bool bPrivate=false;
-	P11ER_CALL(pEncryptKey->IsPrivate(bPrivate),
-		ERR_GET_PRIVATE)
+		bool bPrivate = false;
+		P11ER_CALL(pEncryptKey->IsPrivate(bPrivate),
+			ERR_GET_PRIVATE)
 
-	if (bPrivate && pSlot->User!=CKU_USER)
-		_return(CKR_USER_NOT_LOGGED_IN)
+			if (bPrivate && pSlot->User != CKU_USER)
+				_return(CKR_USER_NOT_LOGGED_IN)
 
-	ByteArray *baAttrVal=NULL;
-	P11ER_CALL(pEncryptKey->getAttribute(CKA_ENCRYPT,baAttrVal),
-		ERR_GET_ATTRIBUTE)
-	if (baAttrVal==NULL)
-		_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
-	else {
-		if (ByteArrayToVar(*baAttrVal,CK_BBOOL)==FALSE)
-			_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
-	}
+				ByteArray *baAttrVal = NULL;
+		P11ER_CALL(pEncryptKey->getAttribute(CKA_ENCRYPT, baAttrVal),
+			ERR_GET_ATTRIBUTE)
+			if (baAttrVal == NULL)
+				_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			else {
+				if (ByteArrayToVar(*baAttrVal, CK_BBOOL) == FALSE)
+					_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			}
 
-	switch (pMechanism->mechanism) {
+		switch (pMechanism->mechanism) {
 		case CKM_RSA_PKCS:
 		{
 			auto mech = std::unique_ptr<CRSA_PKCS1>(new CRSA_PKCS1(shared_from_this()));
 			P11ER_CALL(mech->EncryptInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pEncryptMechanism=std::move(mech);
+				pEncryptMechanism = std::move(mech);
 			break;
 		}
 		case CKM_RSA_X_509:
@@ -1152,139 +1156,139 @@ CK_RV CSession::EncryptInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 			auto mech = std::unique_ptr<CRSA_X509>(new CRSA_X509(shared_from_this()));
 			P11ER_CALL(mech->EncryptInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pEncryptMechanism=std::move(mech);
+				pEncryptMechanism = std::move(mech);
 			break;
 		}
 		default:
 			_return(CKR_MECHANISM_INVALID)
-	}
+		}
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::Encrypt(ByteArray &Data, ByteArray &EncryptedData)
-{
-	init_func
-
-	if (!pEncryptMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	CK_ULONG ulReqLen=0;
-	P11ER_CALL(pEncryptMechanism->EncryptLength(&ulReqLen),
-		ERR_CANT_GET_MECHANISM_LENGTH)
-
-	if (!EncryptedData.isNull() && EncryptedData.size()<ulReqLen)
-		_return(CKR_BUFFER_TOO_SMALL)
-
-	EncryptedData.dwSize=ulReqLen;
-	if (EncryptedData.isNull())
 		_return(OK)
-
-	CK_RV result=EncryptUpdate(Data,EncryptedData);
-	if (result!=OK)
-		_return(result)
-
-	DWORD ret=EncryptFinal(EncryptedData);
-	_return(ret)
-
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::EncryptUpdate(ByteArray &Data,ByteArray &EncryptedData)
-{
-	init_func
-	if (!pEncryptMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	ByteDynArray baEncryptedData;
-	P11ER_CALL(pEncryptMechanism->EncryptUpdate(Data,baEncryptedData),
-		ERR_CANT_UPDATE_MECHANISM)
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::EncryptFinal(ByteArray &EncryptedData)
-{
-	init_func
-	if (!pEncryptMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	auto mech = make_resetter(pEncryptMechanism);
-	CK_ULONG ulReqLen=0;
-	P11ER_CALL(pEncryptMechanism->EncryptLength(&ulReqLen),
-		ERR_CANT_GET_MECHANISM_LENGTH)
-
-	if (!EncryptedData.isNull() && EncryptedData.size()<ulReqLen) {
-		mech.release();
-		_return(CKR_BUFFER_TOO_SMALL)
+			exit_func
+			_return(FAIL)
 	}
 
-	EncryptedData.dwSize=ulReqLen;
-	if (EncryptedData.isNull()) {
-		mech.release();
+	CK_RV CSession::Encrypt(ByteArray &Data, ByteArray &EncryptedData)
+	{
+		init_func
+
+			if (!pEncryptMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+
+				CK_ULONG ulReqLen = 0;
+		P11ER_CALL(pEncryptMechanism->EncryptLength(&ulReqLen),
+			ERR_CANT_GET_MECHANISM_LENGTH)
+
+			if (!EncryptedData.isNull() && EncryptedData.size()<ulReqLen)
+				_return(CKR_BUFFER_TOO_SMALL)
+
+				EncryptedData = EncryptedData.left(ulReqLen);
+		if (EncryptedData.isNull())
+			_return(OK)
+
+			CK_RV result = EncryptUpdate(Data, EncryptedData);
+		if (result != OK)
+			_return(result)
+
+			DWORD ret = EncryptFinal(EncryptedData);
+		_return(ret)
+
+			exit_func
+			_return(FAIL)
+	}
+
+	CK_RV CSession::EncryptUpdate(ByteArray &Data, ByteArray &EncryptedData)
+	{
+		init_func
+			if (!pEncryptMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+
+				ByteDynArray baEncryptedData;
+		P11ER_CALL(pEncryptMechanism->EncryptUpdate(Data, baEncryptedData),
+			ERR_CANT_UPDATE_MECHANISM)
+
+			_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	CK_RV CSession::EncryptFinal(ByteArray &EncryptedData)
+	{
+		init_func
+			if (!pEncryptMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+
+				auto mech = make_resetter(pEncryptMechanism);
+		CK_ULONG ulReqLen = 0;
+		P11ER_CALL(pEncryptMechanism->EncryptLength(&ulReqLen),
+			ERR_CANT_GET_MECHANISM_LENGTH)
+
+			if (!EncryptedData.isNull() && EncryptedData.size()<ulReqLen) {
+				mech.release();
+				_return(CKR_BUFFER_TOO_SMALL)
+			}
+
+		EncryptedData = EncryptedData.left(ulReqLen);
+		if (EncryptedData.isNull()) {
+			mech.release();
+			_return(OK)
+		}
+
+		ByteDynArray baEncryptedBuffer;
+		RESULT ris;
+		if (ris = pEncryptMechanism->EncryptFinal(baEncryptedBuffer))
+			_return(ris)
+
+			EncryptedData.copy(baEncryptedBuffer);
+
 		_return(OK)
+			exit_func
+			_return(FAIL)
 	}
 
-	ByteDynArray baEncryptedBuffer;
-	RESULT ris;
-	if (ris=pEncryptMechanism->EncryptFinal(baEncryptedBuffer))
-		_return(ris)
-	
-	EncryptedData.copy(baEncryptedBuffer);
+	/* ******************** */
+	/*		Decrypt			*/
+	/* ******************** */
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
+	CK_RV CSession::DecryptInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
+	{
+		init_func
+			if (pDecryptMechanism)
+				_return(CKR_OPERATION_ACTIVE)
 
-/* ******************** */
-/*		Decrypt			*/
-/* ******************** */
+				std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(hKey, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_KEY_HANDLE_INVALID)
+				if (pObject->ObjClass != CKO_PRIVATE_KEY)
+					_return(CKR_KEY_HANDLE_INVALID)
+					auto pDecryptKey = std::static_pointer_cast<CP11PrivateKey>(pObject);
 
-CK_RV CSession::DecryptInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
-{
-	init_func
-	if (pDecryptMechanism)
-		_return(CKR_OPERATION_ACTIVE)
+		bool bPrivate = false;
+		P11ER_CALL(pDecryptKey->IsPrivate(bPrivate),
+			ERR_GET_PRIVATE)
 
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(hKey,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_KEY_HANDLE_INVALID)
-	if (pObject->ObjClass!=CKO_PRIVATE_KEY)
-		_return(CKR_KEY_HANDLE_INVALID)
-	auto pDecryptKey= std::static_pointer_cast<CP11PrivateKey>(pObject);
-	
-	bool bPrivate=false;
-	P11ER_CALL(pDecryptKey->IsPrivate(bPrivate),
-		ERR_GET_PRIVATE)
+			if (bPrivate && pSlot->User != CKU_USER)
+				_return(CKR_USER_NOT_LOGGED_IN)
 
-	if (bPrivate && pSlot->User!=CKU_USER)
-		_return(CKR_USER_NOT_LOGGED_IN)
+				ByteArray *baAttrVal = NULL;
+		P11ER_CALL(pDecryptKey->getAttribute(CKA_DECRYPT, baAttrVal),
+			ERR_GET_ATTRIBUTE)
+			if (baAttrVal == NULL)
+				_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			else {
+				if (ByteArrayToVar(*baAttrVal, CK_BBOOL) == FALSE)
+					_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
+			}
 
-	ByteArray *baAttrVal=NULL;
-	P11ER_CALL(pDecryptKey->getAttribute(CKA_DECRYPT,baAttrVal),
-		ERR_GET_ATTRIBUTE)
-	if (baAttrVal==NULL)
-		_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
-	else {
-		if (ByteArrayToVar(*baAttrVal,CK_BBOOL)==FALSE)
-			_return(CKR_KEY_FUNCTION_NOT_PERMITTED)
-	}
-
-	switch (pMechanism->mechanism) {
+		switch (pMechanism->mechanism) {
 		case CKM_RSA_PKCS:
 		{
 			auto mech = std::unique_ptr<CRSA_PKCS1>(new CRSA_PKCS1(shared_from_this()));
 			P11ER_CALL(mech->DecryptInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pDecryptMechanism=std::move(mech);
+				pDecryptMechanism = std::move(mech);
 			break;
 		}
 		case CKM_RSA_X_509:
@@ -1292,568 +1296,568 @@ CK_RV CSession::DecryptInit(CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 			auto mech = std::unique_ptr<CRSA_X509>(new CRSA_X509(shared_from_this()));
 			P11ER_CALL(mech->DecryptInit(hKey),
 				ERR_CANT_INITIALIZE_MECHANISM)
-			pDecryptMechanism=std::move(mech);
+				pDecryptMechanism = std::move(mech);
 			break;
 		}
 		default:
 			_return(CKR_MECHANISM_INVALID)
-	}
+		}
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::Decrypt(ByteArray &EncryptedData, ByteArray &Data)
-{
-	init_func
-
-	if (!pDecryptMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
-
-	bool bFound=false;
-	P11ER_CALL(pDecryptMechanism->checkCache(EncryptedData,Data,bFound),
-		ERR_MECHANISM_CACHE)
-	if (bFound) {
-		pDecryptMechanism.reset();
 		_return(OK)
+			exit_func
+			_return(FAIL)
 	}
 
-	CK_RV result=DecryptUpdate(EncryptedData,Data);
-	if (result!=OK)
-		_return(result)
+	CK_RV CSession::Decrypt(ByteArray &EncryptedData, ByteArray &Data)
+	{
+		init_func
 
-	DWORD ret=DecryptFinal(Data);
+			if (!pDecryptMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
 
-	if (ret==OK && Data.isNull())
-		pDecryptMechanism->cacheData=EncryptedData;
+				bool bFound = false;
+		P11ER_CALL(pDecryptMechanism->checkCache(EncryptedData, Data, bFound),
+			ERR_MECHANISM_CACHE)
+			if (bFound) {
+				pDecryptMechanism.reset();
+				_return(OK)
+			}
 
-	_return(ret)
-	exit_func
-	_return(FAIL)
-}
+		CK_RV result = DecryptUpdate(EncryptedData, Data);
+		if (result != OK)
+			_return(result)
 
-CK_RV CSession::DecryptUpdate(ByteArray &EncryptedData,ByteArray &Data)
-{
-	init_func
-	if (!pDecryptMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
+			DWORD ret = DecryptFinal(Data);
 
-	ByteDynArray baData;
-	P11ER_CALL(pDecryptMechanism->DecryptUpdate(EncryptedData,baData),
-		ERR_CANT_UPDATE_MECHANISM)
+		if (ret == OK && Data.isNull())
+			pDecryptMechanism->cacheData = EncryptedData;
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
+		_return(ret)
+			exit_func
+			_return(FAIL)
+	}
 
-CK_RV CSession::DecryptFinal(ByteArray &Data)
-{
-	init_func
-	if (!pDecryptMechanism)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
+	CK_RV CSession::DecryptUpdate(ByteArray &EncryptedData, ByteArray &Data)
+	{
+		init_func
+			if (!pDecryptMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
 
-	auto mech = make_resetter(pDecryptMechanism);
-	bool bFound=false;
-	P11ER_CALL(pDecryptMechanism->checkCache(ByteArray(),Data,bFound),
-		ERR_MECHANISM_CACHE)
-	if (bFound)
+				ByteDynArray baData;
+		P11ER_CALL(pDecryptMechanism->DecryptUpdate(EncryptedData, baData),
+			ERR_CANT_UPDATE_MECHANISM)
+
+			_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	CK_RV CSession::DecryptFinal(ByteArray &Data)
+	{
+		init_func
+			if (!pDecryptMechanism)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
+
+				auto mech = make_resetter(pDecryptMechanism);
+		bool bFound = false;
+		P11ER_CALL(pDecryptMechanism->checkCache(ByteArray(), Data, bFound),
+			ERR_MECHANISM_CACHE)
+			if (bFound)
+				_return(OK)
+
+				std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(pDecryptMechanism->hDecryptKey, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_KEY_HANDLE_INVALID)
+				if (pObject->ObjClass != CKO_PRIVATE_KEY)
+					_return(CKR_KEY_HANDLE_INVALID)
+					auto pDecryptKey = std::static_pointer_cast<CP11PrivateKey>(pObject);
+
+		bool bPrivate = false;
+		P11ER_CALL(pDecryptKey->IsPrivate(bPrivate),
+			ERR_GET_PRIVATE)
+
+			if (bPrivate && pSlot->User != CKU_USER)
+				_return(CKR_USER_NOT_LOGGED_IN)
+
+				ByteArray *baKeyModule = NULL;
+
+		P11ER_CALL(pDecryptKey->getAttribute(CKA_MODULUS, baKeyModule),
+			ERR_CANT_GET_PUBKEY_MODULUS)
+			ER_ASSERT(baKeyModule != NULL, ERR_CANT_GET_PUBKEY_MODULUS)
+
+			size_t dwKeyLenBytes = baKeyModule->size();
+
+		ByteDynArray baDecryptBuffer;
+		RESULT ris;
+		if (ris = pDecryptMechanism->DecryptFinal(baDecryptBuffer))
+			_return(ris)
+
+			ByteDynArray baData;
+		P11ER_CALL(pSlot->pTemplate->FunctionList.templateDecrypt(pSlot->pTemplateData, pDecryptKey.get(), baDecryptBuffer, baData, pDecryptMechanism->mtType, false),
+			ERR_CANT_SIGN)
+
+			ByteDynArray baUnpaddedData;
+		P11ER_CALL(pDecryptMechanism->DecryptRemovePadding(baData, baUnpaddedData),
+			ERR_PADDING)
+
+			if (Data.isNull()) {
+				P11ER_CALL(pDecryptMechanism->setCache(ByteArray(), baUnpaddedData),
+					ERR_MECHANISM_CACHE)
+					Data = Data.left(baUnpaddedData.size());
+				mech.release();
+			}
+			else if (Data.size()<baUnpaddedData.size()) {
+				P11ER_CALL(pDecryptMechanism->setCache(ByteArray(), baUnpaddedData),
+					ERR_MECHANISM_CACHE)
+					Data = Data.left(baUnpaddedData.size());
+				mech.release();
+				_return(CKR_BUFFER_TOO_SMALL)
+			}
+			else {
+				P11ER_CALL(pDecryptMechanism->setCache(ByteArray(), baUnpaddedData),
+					ERR_MECHANISM_CACHE)
+					Data.copy(baUnpaddedData);
+				Data = Data.left(baUnpaddedData.size());
+			}
+
+			_return(OK)
+				exit_func
+				_return(FAIL)
+	}
+
+	CK_RV CSession::GenerateRandom(ByteArray &RandomData)
+	{
+		init_func
+			ByteDynArray baRandom(RandomData.size());
+		P11ER_CALL(pSlot->pTemplate->FunctionList.templateGenerateRandom(pSlot->pTemplateData, baRandom),
+			ERR_GENERATE_RANDOM)
+			RandomData.copy(baRandom);
 		_return(OK)
-
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(pDecryptMechanism->hDecryptKey,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_KEY_HANDLE_INVALID)
-	if (pObject->ObjClass!=CKO_PRIVATE_KEY)
-		_return(CKR_KEY_HANDLE_INVALID)
-	auto pDecryptKey= std::static_pointer_cast<CP11PrivateKey>(pObject);
-
-	bool bPrivate=false;
-	P11ER_CALL(pDecryptKey->IsPrivate(bPrivate),
-		ERR_GET_PRIVATE)
-
-	if (bPrivate && pSlot->User!=CKU_USER)
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	ByteArray *baKeyModule=NULL;
-
-	P11ER_CALL(pDecryptKey->getAttribute(CKA_MODULUS,baKeyModule),
-		ERR_CANT_GET_PUBKEY_MODULUS)
-	ER_ASSERT(baKeyModule!=NULL,ERR_CANT_GET_PUBKEY_MODULUS)
-
-	DWORD dwKeyLenBytes=baKeyModule->size();
-
-	ByteDynArray baDecryptBuffer;
-	RESULT ris;
-	if (ris=pDecryptMechanism->DecryptFinal(baDecryptBuffer))
-		_return(ris)
-
-	ByteDynArray baData;
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateDecrypt(pSlot->pTemplateData,pDecryptKey.get(),baDecryptBuffer,baData,pDecryptMechanism->mtType,false),
-		ERR_CANT_SIGN)
-
-	ByteDynArray baUnpaddedData;
-	P11ER_CALL(pDecryptMechanism->DecryptRemovePadding(baData,baUnpaddedData),
-		ERR_PADDING)
-
-	if (Data.isNull()) {
-		P11ER_CALL(pDecryptMechanism->setCache(ByteArray(),baUnpaddedData),
-			ERR_MECHANISM_CACHE)
-		Data.dwSize=baUnpaddedData.size();
-		mech.release();
-	}
-	else if (Data.size()<baUnpaddedData.size()) {
-		P11ER_CALL(pDecryptMechanism->setCache(ByteArray(),baUnpaddedData),
-			ERR_MECHANISM_CACHE)
-		Data.dwSize=baUnpaddedData.size();
-		mech.release();
-		_return(CKR_BUFFER_TOO_SMALL)
-	}
-	else {
-		P11ER_CALL(pDecryptMechanism->setCache(ByteArray(),baUnpaddedData),
-			ERR_MECHANISM_CACHE)
-		Data.copy(baUnpaddedData);
-		Data.dwSize=baUnpaddedData.size();
+			exit_func
+			_return(FAIL)
 	}
 
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
+	CK_RV CSession::InitPIN(ByteArray &Pin)
+	{
+		init_func
 
-CK_RV CSession::GenerateRandom(ByteArray &RandomData)
-{
-	init_func
-	ByteDynArray baRandom(RandomData.size());
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateGenerateRandom(pSlot->pTemplateData,baRandom),
-		ERR_GENERATE_RANDOM)
-	RandomData.copy(baRandom);
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
+			if (pSlot->User != CKU_SO)
+				_return(CKR_USER_NOT_LOGGED_IN)
 
-CK_RV CSession::InitPIN(ByteArray &Pin)
-{
-	init_func
-
-	if (pSlot->User!=CKU_SO)
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateInitPIN(pSlot->pTemplateData,Pin),
-		ERR_INIT_PIN)
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::SetPIN(ByteArray &OldPin,ByteArray &NewPin)
-{
-	init_func
-
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateSetPIN(pSlot->pTemplateData,OldPin,NewPin,pSlot->User),
-		ERR_SET_PIN)
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::GetObjectSize(CK_OBJECT_HANDLE hObject,CK_ULONG_PTR pulSize)
-{
-	init_func
-
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(hObject,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_OBJECT_HANDLE_INVALID)
-
-	bool bPrivate=false;
-	P11ER_CALL(pObject->IsPrivate(bPrivate),
-		ERR_GET_PRIVATE)
-
-	if (bPrivate && pSlot->User!=CKU_USER)
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	DWORD ret=pObject->GetObjectSize(pulSize);
-	_return(ret)
-
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::SetAttributeValue(CK_OBJECT_HANDLE hObject,CK_ATTRIBUTE_PTR pTemplate,CK_ULONG ulCount)
-{
-	init_func
-	std::shared_ptr<CP11Object> pObject;
-	P11ER_CALL(pSlot->GetObjectFromID(hObject,pObject),
-		ERR_CANT_GET_OBJECT)
-	if (pObject==NULL)
-		_return(CKR_OBJECT_HANDLE_INVALID)
-
-	if ((flags & CKF_RW_SESSION)==0)
-		_return(CKR_SESSION_READ_ONLY)
-
-	if (pSlot->User!=CKU_USER)
-		_return(CKR_USER_NOT_LOGGED_IN)
-
-	P11ER_CALL(pSlot->pTemplate->FunctionList.templateSetAttribute(pSlot->pTemplateData,pObject.get(),pTemplate,ulCount),
-		ERR_SET_ATTRIBUTE)
-
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::SetOperationState(ByteArray &OperationState)
-{
-	init_func
-	CTLV Tlv(OperationState);	
-
-	ByteArray Flags,User;
-	P11ER_CALL(Tlv.getValue(OS_Flags,Flags),
-		ERR_TLV)
-	if (Flags.isNull()) _return(CKR_SAVED_STATE_INVALID)
-	P11ER_CALL(Tlv.getValue(OS_User,User),
-		ERR_TLV)
-	if (User.isNull()) _return(CKR_SAVED_STATE_INVALID)
-
-	if (Flags!=VarToByteArray(flags))
-		_return(CKR_SAVED_STATE_INVALID)
-	if (User!=VarToByteArray(pSlot->User))
-		_return(CKR_SAVED_STATE_INVALID)
-
-	ByteArray SignOperationState;
-	P11ER_CALL(Tlv.getValue(OS_Sign,SignOperationState),
-		ERR_TLV)
-	if (!SignOperationState.isNull()) {
-		pSignMechanism.reset();
-		CTLV SignTlv(SignOperationState);
-		ByteArray Algo;
-		P11ER_CALL(SignTlv.getValue(OS_Algo,Algo),ERR_TLV)
-		if (Algo.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
-		CK_MECHANISM mech={ByteArrayToVar(Algo,CK_MECHANISM_TYPE),NULL,0};
-
-		ByteArray Key;
-		P11ER_CALL(SignTlv.getValue(OS_Key,Key),ERR_TLV)
-		if (Key.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
-
-		std::shared_ptr<CP11Object> pKey;
-		P11ER_CALL(pSlot->FindP11Object(CKO_PRIVATE_KEY,CKA_ID,Key.lock(),Key.size(),pKey),
-			ERR_FIND_OBJECT)
-		ER_ASSERT(pKey,ERR_CANT_GET_OBJECT)
-		CK_OBJECT_HANDLE hKey;
-		P11ER_CALL(pSlot->GetIDFromObject(pKey,hKey),
-			ERR_GET_OBJECT_HANDLE)
-
-		ByteArray Data;
-		P11ER_CALL(SignTlv.getValue(OS_Data,Data),ERR_TLV)
-		if (Data.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
-
-		P11ER_CALL(SignInit(&mech,hKey),
-			ERR_CANT_INITIALIZE_MECHANISM);
-
-		P11ER_CALL(pSignMechanism->SignSetOperationState(Data),
-			ERR_SET_OPERATION_STATE)
+				P11ER_CALL(pSlot->pTemplate->FunctionList.templateInitPIN(pSlot->pTemplateData, Pin),
+				ERR_INIT_PIN)
+				_return(OK)
+				exit_func
+				_return(FAIL)
 	}
 
-	ByteArray DecryptOperationState;
-	P11ER_CALL(Tlv.getValue(OS_Decrypt,DecryptOperationState),
-		ERR_TLV)
-	if (!DecryptOperationState.isNull()) {
-		pDecryptMechanism.reset();
-		CTLV DecryptTlv(DecryptOperationState);
-		ByteArray Algo;
-		P11ER_CALL(DecryptTlv.getValue(OS_Algo,Algo),ERR_TLV)
-		if (Algo.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
-		CK_MECHANISM mech={ByteArrayToVar(Algo,CK_MECHANISM_TYPE),NULL,0};
+	CK_RV CSession::SetPIN(ByteArray &OldPin, ByteArray &NewPin)
+	{
+		init_func
 
-		ByteArray Key;
-		P11ER_CALL(DecryptTlv.getValue(OS_Key,Key),ERR_TLV)
-		if (Key.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
-
-		std::shared_ptr<CP11Object> pKey;
-		P11ER_CALL(pSlot->FindP11Object(CKO_PRIVATE_KEY,CKA_ID,Key.lock(),Key.size(),pKey),
-			ERR_FIND_OBJECT)
-		ER_ASSERT(pKey,ERR_CANT_GET_OBJECT)
-		CK_OBJECT_HANDLE hKey;
-		P11ER_CALL(pSlot->GetIDFromObject(pKey,hKey),
-			ERR_GET_OBJECT_HANDLE)
-
-		ByteArray Data;
-		P11ER_CALL(DecryptTlv.getValue(OS_Data,Data),ERR_TLV)
-		if (Data.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
-
-		P11ER_CALL(DecryptInit(&mech,hKey),
-			ERR_CANT_INITIALIZE_MECHANISM);
-
-		P11ER_CALL(pDecryptMechanism->DecryptSetOperationState(Data),
-			ERR_SET_OPERATION_STATE)
+			P11ER_CALL(pSlot->pTemplate->FunctionList.templateSetPIN(pSlot->pTemplateData, OldPin, NewPin, pSlot->User),
+			ERR_SET_PIN)
+			_return(OK)
+			exit_func
+			_return(FAIL)
 	}
 
-	ByteArray VerifyOperationState;
-	P11ER_CALL(Tlv.getValue(OS_Verify,VerifyOperationState),
-		ERR_TLV)
-	if (!VerifyOperationState.isNull()) {
-		pVerifyMechanism.reset();
-		CTLV VerifyTlv(VerifyOperationState);
-		ByteArray Algo;
-		P11ER_CALL(VerifyTlv.getValue(OS_Algo,Algo),ERR_TLV)
-		if (Algo.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
-		CK_MECHANISM mech={ByteArrayToVar(Algo,CK_MECHANISM_TYPE),NULL,0};
+	CK_RV CSession::GetObjectSize(CK_OBJECT_HANDLE hObject, CK_ULONG_PTR pulSize)
+	{
+		init_func
 
-		ByteArray Key;
-		P11ER_CALL(VerifyTlv.getValue(OS_Key,Key),ERR_TLV)
-		if (Key.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
+			std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(hObject, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_OBJECT_HANDLE_INVALID)
 
-		std::shared_ptr<CP11Object> pKey;
-		P11ER_CALL(pSlot->FindP11Object(CKO_PUBLIC_KEY,CKA_ID,Key.lock(),Key.size(),pKey),
-			ERR_FIND_OBJECT)
-		ER_ASSERT(pKey,ERR_CANT_GET_OBJECT)
-		CK_OBJECT_HANDLE hKey;
-		P11ER_CALL(pSlot->GetIDFromObject(pKey,hKey),
-			ERR_GET_OBJECT_HANDLE)
+				bool bPrivate = false;
+		P11ER_CALL(pObject->IsPrivate(bPrivate),
+			ERR_GET_PRIVATE)
 
-		ByteArray Data;
-		P11ER_CALL(VerifyTlv.getValue(OS_Data,Data),ERR_TLV)
-		if (Data.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
+			if (bPrivate && pSlot->User != CKU_USER)
+				_return(CKR_USER_NOT_LOGGED_IN)
 
-		P11ER_CALL(VerifyInit(&mech,hKey),
-			ERR_CANT_INITIALIZE_MECHANISM);
+				DWORD ret = pObject->GetObjectSize(pulSize);
+		_return(ret)
 
-		P11ER_CALL(pVerifyMechanism->VerifySetOperationState(Data),
-			ERR_SET_OPERATION_STATE)
+			exit_func
+			_return(FAIL)
 	}
 
-	ByteArray EncryptOperationState;
-	P11ER_CALL(Tlv.getValue(OS_Encrypt,EncryptOperationState),
-		ERR_TLV)
-	if (!EncryptOperationState.isNull()) {
-		pEncryptMechanism.reset();
-		CTLV EncryptTlv(EncryptOperationState);
-		ByteArray Algo;
-		P11ER_CALL(EncryptTlv.getValue(OS_Algo,Algo),ERR_TLV)
-		if (Algo.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
-		CK_MECHANISM mech={ByteArrayToVar(Algo,CK_MECHANISM_TYPE),NULL,0};
+	CK_RV CSession::SetAttributeValue(CK_OBJECT_HANDLE hObject, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount)
+	{
+		init_func
+			std::shared_ptr<CP11Object> pObject;
+		P11ER_CALL(pSlot->GetObjectFromID(hObject, pObject),
+			ERR_CANT_GET_OBJECT)
+			if (pObject == NULL)
+				_return(CKR_OBJECT_HANDLE_INVALID)
 
-		ByteArray Key;
-		P11ER_CALL(EncryptTlv.getValue(OS_Key,Key),ERR_TLV)
-		if (Key.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
+				if ((flags & CKF_RW_SESSION) == 0)
+					_return(CKR_SESSION_READ_ONLY)
 
-		std::shared_ptr<CP11Object> pKey;
-		P11ER_CALL(pSlot->FindP11Object(CKO_PUBLIC_KEY,CKA_ID,Key.lock(),Key.size(),pKey),
-			ERR_FIND_OBJECT)
-		ER_ASSERT(pKey,ERR_CANT_GET_OBJECT)
-		CK_OBJECT_HANDLE hKey;
-		P11ER_CALL(pSlot->GetIDFromObject(pKey,hKey),
-			ERR_GET_OBJECT_HANDLE)
+					if (pSlot->User != CKU_USER)
+						_return(CKR_USER_NOT_LOGGED_IN)
 
-		ByteArray Data;
-		P11ER_CALL(EncryptTlv.getValue(OS_Data,Data),ERR_TLV)
-		if (Data.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
+						P11ER_CALL(pSlot->pTemplate->FunctionList.templateSetAttribute(pSlot->pTemplateData, pObject.get(), pTemplate, ulCount),
+						ERR_SET_ATTRIBUTE)
 
-		P11ER_CALL(EncryptInit(&mech,hKey),
-			ERR_CANT_INITIALIZE_MECHANISM);
 
-		P11ER_CALL(pEncryptMechanism->EncryptSetOperationState(Data),
-			ERR_SET_OPERATION_STATE)
+						_return(OK)
+						exit_func
+						_return(FAIL)
 	}
 
-	ByteArray DigestOperationState;
-	P11ER_CALL(Tlv.getValue(OS_Digest,DigestOperationState),
-		ERR_TLV)
-	if (!DigestOperationState.isNull()) {
-		pDigestMechanism.reset();
-		CTLV DigestTlv(DigestOperationState);
-		ByteArray Algo;
-		P11ER_CALL(DigestTlv.getValue(OS_Algo,Algo),ERR_TLV)
-		if (Algo.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
-		CK_MECHANISM mech={ByteArrayToVar(Algo,CK_MECHANISM_TYPE),NULL,0};
+	CK_RV CSession::SetOperationState(ByteArray &OperationState)
+	{
+		init_func
+			CTLV Tlv(OperationState);
 
-		ByteArray Data;
-		P11ER_CALL(DigestTlv.getValue(OS_Data,Data),ERR_TLV)
-		if (Data.isNull())
-			_return(CKR_SAVED_STATE_INVALID)
-
-		P11ER_CALL(DigestInit(&mech),
-			ERR_CANT_INITIALIZE_MECHANISM);
-
-		P11ER_CALL(pDigestMechanism->DigestSetOperationState(Data),
-			ERR_SET_OPERATION_STATE)
-	}
-
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
-
-CK_RV CSession::GetOperationState(ByteArray &OperationState)
-{
-	init_func
-
-	CTLVCreate Tlv;
-	Tlv.setValue(OS_Flags,ByteArray((BYTE*)&flags,sizeof(flags)));
-	Tlv.setValue(OS_User,ByteArray((BYTE*)&pSlot->User,sizeof(pSlot->User)));
-	if (pSignMechanism) {
-		CTLVCreate SignTlv;
-		P11ER_CALL(SignTlv.setValue(OS_Algo,ByteArray((BYTE*)&pSignMechanism->mtType,sizeof(pSignMechanism->mtType))),
+		ByteArray Flags, User;
+		P11ER_CALL(Tlv.getValue(OS_Flags, Flags),
 			ERR_TLV)
-		ByteDynArray SignData;
-		P11ER_CALL(pSignMechanism->SignGetOperationState(SignData),
-			ERR_GET_OPERATION_STATE)
-		if (!SignData.isEmpty()) {
-			P11ER_CALL(SignTlv.setValue(OS_Data,SignData),
+			if (Flags.isNull()) _return(CKR_SAVED_STATE_INVALID)
+				P11ER_CALL(Tlv.getValue(OS_User, User),
+				ERR_TLV)
+				if (User.isNull()) _return(CKR_SAVED_STATE_INVALID)
+
+					if (Flags != VarToByteArray(flags))
+						_return(CKR_SAVED_STATE_INVALID)
+						if (User != VarToByteArray(pSlot->User))
+							_return(CKR_SAVED_STATE_INVALID)
+
+							ByteArray SignOperationState;
+		P11ER_CALL(Tlv.getValue(OS_Sign, SignOperationState),
+			ERR_TLV)
+			if (!SignOperationState.isNull()) {
+				pSignMechanism.reset();
+				CTLV SignTlv(SignOperationState);
+				ByteArray Algo;
+				P11ER_CALL(SignTlv.getValue(OS_Algo, Algo), ERR_TLV)
+					if (Algo.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+						CK_MECHANISM mech = { ByteArrayToVar(Algo, CK_MECHANISM_TYPE), NULL, 0 };
+
+				ByteArray Key;
+				P11ER_CALL(SignTlv.getValue(OS_Key, Key), ERR_TLV)
+					if (Key.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+
+						std::shared_ptr<CP11Object> pKey;
+				P11ER_CALL(pSlot->FindP11Object(CKO_PRIVATE_KEY, CKA_ID, Key.data(), (int)Key.size(), pKey),
+					ERR_FIND_OBJECT)
+					ER_ASSERT(pKey, ERR_CANT_GET_OBJECT)
+					CK_OBJECT_HANDLE hKey;
+				P11ER_CALL(pSlot->GetIDFromObject(pKey, hKey),
+					ERR_GET_OBJECT_HANDLE)
+
+					ByteArray Data;
+				P11ER_CALL(SignTlv.getValue(OS_Data, Data), ERR_TLV)
+					if (Data.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+
+						P11ER_CALL(SignInit(&mech, hKey),
+						ERR_CANT_INITIALIZE_MECHANISM);
+
+				P11ER_CALL(pSignMechanism->SignSetOperationState(Data),
+					ERR_SET_OPERATION_STATE)
+			}
+
+		ByteArray DecryptOperationState;
+		P11ER_CALL(Tlv.getValue(OS_Decrypt, DecryptOperationState),
+			ERR_TLV)
+			if (!DecryptOperationState.isNull()) {
+				pDecryptMechanism.reset();
+				CTLV DecryptTlv(DecryptOperationState);
+				ByteArray Algo;
+				P11ER_CALL(DecryptTlv.getValue(OS_Algo, Algo), ERR_TLV)
+					if (Algo.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+						CK_MECHANISM mech = { ByteArrayToVar(Algo, CK_MECHANISM_TYPE), NULL, 0 };
+
+				ByteArray Key;
+				P11ER_CALL(DecryptTlv.getValue(OS_Key, Key), ERR_TLV)
+					if (Key.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+
+						std::shared_ptr<CP11Object> pKey;
+				P11ER_CALL(pSlot->FindP11Object(CKO_PRIVATE_KEY, CKA_ID, Key.data(), (int)Key.size(), pKey),
+					ERR_FIND_OBJECT)
+					ER_ASSERT(pKey, ERR_CANT_GET_OBJECT)
+					CK_OBJECT_HANDLE hKey;
+				P11ER_CALL(pSlot->GetIDFromObject(pKey, hKey),
+					ERR_GET_OBJECT_HANDLE)
+
+					ByteArray Data;
+				P11ER_CALL(DecryptTlv.getValue(OS_Data, Data), ERR_TLV)
+					if (Data.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+
+						P11ER_CALL(DecryptInit(&mech, hKey),
+						ERR_CANT_INITIALIZE_MECHANISM);
+
+				P11ER_CALL(pDecryptMechanism->DecryptSetOperationState(Data),
+					ERR_SET_OPERATION_STATE)
+			}
+
+		ByteArray VerifyOperationState;
+		P11ER_CALL(Tlv.getValue(OS_Verify, VerifyOperationState),
+			ERR_TLV)
+			if (!VerifyOperationState.isNull()) {
+				pVerifyMechanism.reset();
+				CTLV VerifyTlv(VerifyOperationState);
+				ByteArray Algo;
+				P11ER_CALL(VerifyTlv.getValue(OS_Algo, Algo), ERR_TLV)
+					if (Algo.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+						CK_MECHANISM mech = { ByteArrayToVar(Algo, CK_MECHANISM_TYPE), NULL, 0 };
+
+				ByteArray Key;
+				P11ER_CALL(VerifyTlv.getValue(OS_Key, Key), ERR_TLV)
+					if (Key.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+
+						std::shared_ptr<CP11Object> pKey;
+				P11ER_CALL(pSlot->FindP11Object(CKO_PUBLIC_KEY, CKA_ID, Key.data(), (int)Key.size(), pKey),
+					ERR_FIND_OBJECT)
+					ER_ASSERT(pKey, ERR_CANT_GET_OBJECT)
+					CK_OBJECT_HANDLE hKey;
+				P11ER_CALL(pSlot->GetIDFromObject(pKey, hKey),
+					ERR_GET_OBJECT_HANDLE)
+
+					ByteArray Data;
+				P11ER_CALL(VerifyTlv.getValue(OS_Data, Data), ERR_TLV)
+					if (Data.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+
+						P11ER_CALL(VerifyInit(&mech, hKey),
+						ERR_CANT_INITIALIZE_MECHANISM);
+
+				P11ER_CALL(pVerifyMechanism->VerifySetOperationState(Data),
+					ERR_SET_OPERATION_STATE)
+			}
+
+		ByteArray EncryptOperationState;
+		P11ER_CALL(Tlv.getValue(OS_Encrypt, EncryptOperationState),
+			ERR_TLV)
+			if (!EncryptOperationState.isNull()) {
+				pEncryptMechanism.reset();
+				CTLV EncryptTlv(EncryptOperationState);
+				ByteArray Algo;
+				P11ER_CALL(EncryptTlv.getValue(OS_Algo, Algo), ERR_TLV)
+					if (Algo.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+						CK_MECHANISM mech = { ByteArrayToVar(Algo, CK_MECHANISM_TYPE), NULL, 0 };
+
+				ByteArray Key;
+				P11ER_CALL(EncryptTlv.getValue(OS_Key, Key), ERR_TLV)
+					if (Key.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+
+						std::shared_ptr<CP11Object> pKey;
+				P11ER_CALL(pSlot->FindP11Object(CKO_PUBLIC_KEY, CKA_ID, Key.data(), (int)Key.size(), pKey),
+					ERR_FIND_OBJECT)
+					ER_ASSERT(pKey, ERR_CANT_GET_OBJECT)
+					CK_OBJECT_HANDLE hKey;
+				P11ER_CALL(pSlot->GetIDFromObject(pKey, hKey),
+					ERR_GET_OBJECT_HANDLE)
+
+					ByteArray Data;
+				P11ER_CALL(EncryptTlv.getValue(OS_Data, Data), ERR_TLV)
+					if (Data.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+
+						P11ER_CALL(EncryptInit(&mech, hKey),
+						ERR_CANT_INITIALIZE_MECHANISM);
+
+				P11ER_CALL(pEncryptMechanism->EncryptSetOperationState(Data),
+					ERR_SET_OPERATION_STATE)
+			}
+
+		ByteArray DigestOperationState;
+		P11ER_CALL(Tlv.getValue(OS_Digest, DigestOperationState),
+			ERR_TLV)
+			if (!DigestOperationState.isNull()) {
+				pDigestMechanism.reset();
+				CTLV DigestTlv(DigestOperationState);
+				ByteArray Algo;
+				P11ER_CALL(DigestTlv.getValue(OS_Algo, Algo), ERR_TLV)
+					if (Algo.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+						CK_MECHANISM mech = { ByteArrayToVar(Algo, CK_MECHANISM_TYPE), NULL, 0 };
+
+				ByteArray Data;
+				P11ER_CALL(DigestTlv.getValue(OS_Data, Data), ERR_TLV)
+					if (Data.isNull())
+						_return(CKR_SAVED_STATE_INVALID)
+
+						P11ER_CALL(DigestInit(&mech),
+						ERR_CANT_INITIALIZE_MECHANISM);
+
+				P11ER_CALL(pDigestMechanism->DigestSetOperationState(Data),
+					ERR_SET_OPERATION_STATE)
+			}
+
+		_return(OK)
+			exit_func
+			_return(FAIL)
+	}
+
+	CK_RV CSession::GetOperationState(ByteArray &OperationState)
+	{
+		init_func
+
+			CTLVCreate Tlv;
+		Tlv.setValue(OS_Flags, ByteArray((BYTE*)&flags, sizeof(flags)));
+		Tlv.setValue(OS_User, ByteArray((BYTE*)&pSlot->User, sizeof(pSlot->User)));
+		if (pSignMechanism) {
+			CTLVCreate SignTlv;
+			P11ER_CALL(SignTlv.setValue(OS_Algo, ByteArray((BYTE*)&pSignMechanism->mtType, sizeof(pSignMechanism->mtType))),
+				ERR_TLV)
+				ByteDynArray SignData;
+			P11ER_CALL(pSignMechanism->SignGetOperationState(SignData),
+				ERR_GET_OPERATION_STATE)
+				if (!SignData.isEmpty()) {
+					P11ER_CALL(SignTlv.setValue(OS_Data, SignData),
+						ERR_TLV)
+				}
+
+			std::shared_ptr<CP11Object> pKey;
+			P11ER_CALL(pSlot->GetObjectFromID(pSignMechanism->hSignKey, pKey),
+				ERR_CANT_GET_OBJECT)
+				ER_ASSERT(pKey, ERR_CANT_GET_OBJECT);
+			ByteArray *SignKeyID = NULL;
+			P11ER_CALL(pKey->getAttribute(CKA_ID, SignKeyID), ERR_GET_ATTRIBUTE);
+			ER_ASSERT(SignKeyID, ERR_CANT_FIND_ID);
+			SignTlv.setValue(OS_Key, *SignKeyID);
+
+			ByteDynArray *SignOperationState;
+			P11ER_CALL(Tlv.addValue(OS_Sign, SignOperationState),
+				ERR_TLV)
+				P11ER_CALL(SignTlv.getBuffer(*SignOperationState),
 				ERR_TLV)
 		}
+		if (pVerifyMechanism) {
+			CTLVCreate VerifyTlv;
+			P11ER_CALL(VerifyTlv.setValue(OS_Algo, ByteArray((BYTE*)&pVerifyMechanism->mtType, sizeof(pVerifyMechanism->mtType))),
+				ERR_TLV)
+				ByteDynArray verifyData;
+			P11ER_CALL(pVerifyMechanism->VerifyGetOperationState(verifyData),
+				ERR_GET_OPERATION_STATE)
+				if (!verifyData.isEmpty()) {
+					P11ER_CALL(VerifyTlv.setValue(OS_Data, verifyData),
+						ERR_TLV)
+				}
 
-		std::shared_ptr<CP11Object> pKey;
-		P11ER_CALL(pSlot->GetObjectFromID(pSignMechanism->hSignKey,pKey),
-			ERR_CANT_GET_OBJECT)
-		ER_ASSERT(pKey,ERR_CANT_GET_OBJECT);
-		ByteArray *SignKeyID=NULL;
-		P11ER_CALL(pKey->getAttribute(CKA_ID,SignKeyID),ERR_GET_ATTRIBUTE);
-		ER_ASSERT(SignKeyID,ERR_CANT_FIND_ID);
-		SignTlv.setValue(OS_Key,*SignKeyID);
+			std::shared_ptr<CP11Object> pKey;
+			P11ER_CALL(pSlot->GetObjectFromID(pVerifyMechanism->hVerifyKey, pKey),
+				ERR_CANT_GET_OBJECT)
+				ER_ASSERT(pKey, ERR_CANT_GET_OBJECT);
+			ByteArray *VerifyKeyID = NULL;
+			P11ER_CALL(pKey->getAttribute(CKA_ID, VerifyKeyID), ERR_GET_ATTRIBUTE);
+			ER_ASSERT(VerifyKeyID, ERR_CANT_FIND_ID);
+			VerifyTlv.setValue(OS_Key, *VerifyKeyID);
 
-		ByteDynArray *SignOperationState;
-		P11ER_CALL(Tlv.addValue(OS_Sign,SignOperationState),
-			ERR_TLV)
-		P11ER_CALL(SignTlv.getBuffer(*SignOperationState),
-			ERR_TLV)
-	}
-	if (pVerifyMechanism) {
-		CTLVCreate VerifyTlv;
-		P11ER_CALL(VerifyTlv.setValue(OS_Algo,ByteArray((BYTE*)&pVerifyMechanism->mtType,sizeof(pVerifyMechanism->mtType))),
-			ERR_TLV)
-		ByteDynArray verifyData;
-		P11ER_CALL(pVerifyMechanism->VerifyGetOperationState(verifyData),
-			ERR_GET_OPERATION_STATE)
-		if (!verifyData.isEmpty()) {
-			P11ER_CALL(VerifyTlv.setValue(OS_Data,verifyData),
+			ByteDynArray *VerifyOperationState;
+			P11ER_CALL(Tlv.addValue(OS_Verify, VerifyOperationState),
+				ERR_TLV)
+				P11ER_CALL(VerifyTlv.getBuffer(*VerifyOperationState),
 				ERR_TLV)
 		}
+		if (pDigestMechanism) {
+			CTLVCreate DigestTlv;
+			P11ER_CALL(DigestTlv.setValue(OS_Algo, ByteArray((BYTE*)&pDigestMechanism->mtType, sizeof(pDigestMechanism->mtType))),
+				ERR_TLV)
+				ByteDynArray DigestData;
+			P11ER_CALL(pDigestMechanism->DigestGetOperationState(DigestData),
+				ERR_GET_OPERATION_STATE)
+				if (!DigestData.isEmpty())
+					P11ER_CALL(DigestTlv.setValue(OS_Data, DigestData),
+					ERR_TLV)
 
-		std::shared_ptr<CP11Object> pKey;
-		P11ER_CALL(pSlot->GetObjectFromID(pVerifyMechanism->hVerifyKey,pKey),
-			ERR_CANT_GET_OBJECT)
-		ER_ASSERT(pKey,ERR_CANT_GET_OBJECT);
-		ByteArray *VerifyKeyID=NULL;
-		P11ER_CALL(pKey->getAttribute(CKA_ID,VerifyKeyID),ERR_GET_ATTRIBUTE);
-		ER_ASSERT(VerifyKeyID,ERR_CANT_FIND_ID);
-		VerifyTlv.setValue(OS_Key,*VerifyKeyID);
-
-		ByteDynArray *VerifyOperationState;
-		P11ER_CALL(Tlv.addValue(OS_Verify,VerifyOperationState),
-			ERR_TLV)
-		P11ER_CALL(VerifyTlv.getBuffer(*VerifyOperationState),
-			ERR_TLV)
-	}
-	if (pDigestMechanism) {
-		CTLVCreate DigestTlv;
-		P11ER_CALL(DigestTlv.setValue(OS_Algo,ByteArray((BYTE*)&pDigestMechanism->mtType,sizeof(pDigestMechanism->mtType))),
-			ERR_TLV)
-		ByteDynArray DigestData;
-		P11ER_CALL(pDigestMechanism->DigestGetOperationState(DigestData),
-			ERR_GET_OPERATION_STATE)
-		if (!DigestData.isEmpty())
-			P11ER_CALL(DigestTlv.setValue(OS_Data,DigestData),
-			ERR_TLV)
-
-		ByteDynArray *DigestOperationState;
-		P11ER_CALL(Tlv.addValue(OS_Digest,DigestOperationState),
-			ERR_TLV)
-		P11ER_CALL(DigestTlv.getBuffer(*DigestOperationState),
-			ERR_TLV)
-	}
-	if (pEncryptMechanism) {
-		CTLVCreate EncryptTlv;
-		P11ER_CALL(EncryptTlv.setValue(OS_Algo,ByteArray((BYTE*)&pEncryptMechanism->mtType,sizeof(pEncryptMechanism->mtType))),
-			ERR_TLV)
-		ByteDynArray EncryptData;
-		P11ER_CALL(pEncryptMechanism->EncryptGetOperationState(EncryptData),
-			ERR_GET_OPERATION_STATE)
-		if (!EncryptData.isEmpty()) {
-			P11ER_CALL(EncryptTlv.setValue(OS_Data,EncryptData),
-			ERR_TLV)
+					ByteDynArray *DigestOperationState;
+			P11ER_CALL(Tlv.addValue(OS_Digest, DigestOperationState),
+				ERR_TLV)
+				P11ER_CALL(DigestTlv.getBuffer(*DigestOperationState),
+				ERR_TLV)
 		}
+		if (pEncryptMechanism) {
+			CTLVCreate EncryptTlv;
+			P11ER_CALL(EncryptTlv.setValue(OS_Algo, ByteArray((BYTE*)&pEncryptMechanism->mtType, sizeof(pEncryptMechanism->mtType))),
+				ERR_TLV)
+				ByteDynArray EncryptData;
+			P11ER_CALL(pEncryptMechanism->EncryptGetOperationState(EncryptData),
+				ERR_GET_OPERATION_STATE)
+				if (!EncryptData.isEmpty()) {
+					P11ER_CALL(EncryptTlv.setValue(OS_Data, EncryptData),
+						ERR_TLV)
+				}
 
-		std::shared_ptr<CP11Object> pKey;
-		P11ER_CALL(pSlot->GetObjectFromID(pEncryptMechanism->hEncryptKey,pKey),
-			ERR_CANT_GET_OBJECT)
-		ER_ASSERT(pKey,ERR_CANT_GET_OBJECT);
-		ByteArray *EncryptKeyID=NULL;
-		P11ER_CALL(pKey->getAttribute(CKA_ID,EncryptKeyID),ERR_GET_ATTRIBUTE);
-		ER_ASSERT(EncryptKeyID,ERR_CANT_FIND_ID);
-		EncryptTlv.setValue(OS_Key,*EncryptKeyID);
+			std::shared_ptr<CP11Object> pKey;
+			P11ER_CALL(pSlot->GetObjectFromID(pEncryptMechanism->hEncryptKey, pKey),
+				ERR_CANT_GET_OBJECT)
+				ER_ASSERT(pKey, ERR_CANT_GET_OBJECT);
+			ByteArray *EncryptKeyID = NULL;
+			P11ER_CALL(pKey->getAttribute(CKA_ID, EncryptKeyID), ERR_GET_ATTRIBUTE);
+			ER_ASSERT(EncryptKeyID, ERR_CANT_FIND_ID);
+			EncryptTlv.setValue(OS_Key, *EncryptKeyID);
 
-		ByteDynArray *EncryptOperationState;
-		P11ER_CALL(Tlv.addValue(OS_Encrypt,EncryptOperationState),
-			ERR_TLV)
-		P11ER_CALL(EncryptTlv.getBuffer(*EncryptOperationState),
-			ERR_TLV)
-	}	
-	if (pDecryptMechanism) {
-		CTLVCreate DecryptTlv;
-		P11ER_CALL(DecryptTlv.setValue(OS_Algo,ByteArray((BYTE*)&pDecryptMechanism->mtType,sizeof(pDecryptMechanism->mtType))),
-			ERR_TLV)
-		ByteDynArray DecryptData;
-		P11ER_CALL(pDecryptMechanism->DecryptGetOperationState(DecryptData),
-			ERR_GET_OPERATION_STATE)
-		if (!DecryptData.isEmpty()) {
-			P11ER_CALL(DecryptTlv.setValue(OS_Data,DecryptData),
-			ERR_TLV)
+			ByteDynArray *EncryptOperationState;
+			P11ER_CALL(Tlv.addValue(OS_Encrypt, EncryptOperationState),
+				ERR_TLV)
+				P11ER_CALL(EncryptTlv.getBuffer(*EncryptOperationState),
+				ERR_TLV)
 		}
+		if (pDecryptMechanism) {
+			CTLVCreate DecryptTlv;
+			P11ER_CALL(DecryptTlv.setValue(OS_Algo, ByteArray((BYTE*)&pDecryptMechanism->mtType, sizeof(pDecryptMechanism->mtType))),
+				ERR_TLV)
+				ByteDynArray DecryptData;
+			P11ER_CALL(pDecryptMechanism->DecryptGetOperationState(DecryptData),
+				ERR_GET_OPERATION_STATE)
+				if (!DecryptData.isEmpty()) {
+					P11ER_CALL(DecryptTlv.setValue(OS_Data, DecryptData),
+						ERR_TLV)
+				}
 
-		std::shared_ptr<CP11Object> pKey;
-		P11ER_CALL(pSlot->GetObjectFromID(pDecryptMechanism->hDecryptKey,pKey),
-			ERR_CANT_GET_OBJECT)
-		ER_ASSERT(pKey,ERR_CANT_GET_OBJECT);
-		ByteArray *DecryptKeyID=NULL;
-		P11ER_CALL(pKey->getAttribute(CKA_ID,DecryptKeyID),ERR_GET_ATTRIBUTE);
-		ER_ASSERT(DecryptKeyID,ERR_CANT_FIND_ID);
-		DecryptTlv.setValue(OS_Key,*DecryptKeyID);
+			std::shared_ptr<CP11Object> pKey;
+			P11ER_CALL(pSlot->GetObjectFromID(pDecryptMechanism->hDecryptKey, pKey),
+				ERR_CANT_GET_OBJECT)
+				ER_ASSERT(pKey, ERR_CANT_GET_OBJECT);
+			ByteArray *DecryptKeyID = NULL;
+			P11ER_CALL(pKey->getAttribute(CKA_ID, DecryptKeyID), ERR_GET_ATTRIBUTE);
+			ER_ASSERT(DecryptKeyID, ERR_CANT_FIND_ID);
+			DecryptTlv.setValue(OS_Key, *DecryptKeyID);
 
-		ByteDynArray *DecryptOperationState;
-		P11ER_CALL(Tlv.addValue(OS_Decrypt,DecryptOperationState),
+			ByteDynArray *DecryptOperationState;
+			P11ER_CALL(Tlv.addValue(OS_Decrypt, DecryptOperationState),
+				ERR_TLV)
+				P11ER_CALL(DecryptTlv.getBuffer(*DecryptOperationState),
+				ERR_TLV)
+		}
+		ByteDynArray newOperationState;
+		P11ER_CALL(Tlv.getBuffer(newOperationState),
 			ERR_TLV)
-		P11ER_CALL(DecryptTlv.getBuffer(*DecryptOperationState),
-			ERR_TLV)
-	}
-	ByteDynArray newOperationState;
-	P11ER_CALL(Tlv.getBuffer(newOperationState),
-		ERR_TLV)
 
-	if (newOperationState.size()==0)
-		_return(CKR_OPERATION_NOT_INITIALIZED)
+			if (newOperationState.size() == 0)
+				_return(CKR_OPERATION_NOT_INITIALIZED)
 
-	if (OperationState.isNull()) {
-		OperationState.dwSize=newOperationState.size();
+				if (OperationState.isNull()) {
+					OperationState = OperationState.left(newOperationState.size());
+					_return(OK)
+				}
+		if (OperationState.size()<newOperationState.size())
+			_return(CKR_BUFFER_TOO_SMALL)
+
+			OperationState.copy(newOperationState);
 		_return(OK)
+			exit_func
+			_return(FAIL)
 	}
-	if (OperationState.size()<newOperationState.size())
-		_return(CKR_BUFFER_TOO_SMALL)
-
-	OperationState.copy(newOperationState);
-	_return(OK)
-	exit_func
-	_return(FAIL)
-}
 
 };
 

--- a/CSP/Util/Array.cpp
+++ b/CSP/Util/Array.cpp
@@ -1,0 +1,275 @@
+#include "array.h"
+
+
+ByteArray::ByteArray() {
+	_data = nullptr;
+	_size = 0;
+}
+
+ByteArray::ByteArray(uint8_t* data, size_t size) {
+	_data = data;
+	_size = size;
+}
+
+ByteDynArray::ByteDynArray(ByteDynArray &&src) {
+	_data = src._data;
+	_size = src._size;
+	src._data = nullptr;
+	src._size = 0;
+}
+
+ByteArray::ByteArray(const ByteArray& ba, size_t start) {
+	if (start>ba.size())
+		throw std::runtime_error("Array derivato troppo grande");
+	_size = ba.size() - start;
+	_data = ba._data + start;
+}
+
+ByteArray::ByteArray(const ByteArray& ba, size_t start, size_t size) {
+	if (start + size>ba.size())
+		throw std::runtime_error("Array derivato troppo grande");
+	_size = size;
+	_data = ba._data + start;
+}
+
+ByteArray::ByteArray(const ByteArray &src) {
+	_size = src._size;
+	_data = src._data;
+};
+
+ByteDynArray &ByteDynArray::operator = (ByteDynArray &&src) {
+	_data = src._data;
+	_size = src._size;
+	src._data = nullptr;
+	src._size = 0;
+	return *this;
+}
+
+bool ByteArray::operator==(const ByteArray &src) const {
+	if (_size != src._size)
+		return false;
+	return (memcmp(_data, src._data, _size) == 0);
+
+};
+
+int ByteArray::atoi() const {
+	int val = 0;
+	for (size_t i = 0; i<_size; i++) {
+		if (val>(INT_MAX / 10))
+			throw std::overflow_error("owerflow");
+		val = (val * 10) + _data[i] - '0';
+	}
+	return val;
+}
+bool ByteArray::operator<(const ByteArray &src) const {
+	if (_size<src._size)
+		return true;
+	return (memcmp(_data, src._data, _size)<0);
+};
+
+bool ByteArray::operator>(const ByteArray &src) const {
+
+	if (_size>src._size)
+		return true;
+	return (memcmp(_data, src._data, _size)>0);
+};
+
+bool ByteArray::operator!=(const ByteArray &src) const {
+	if (_size != src._size)
+		return true;
+	return (memcmp(_data, src._data, _size) != 0);
+};
+
+void ByteArray::copy(const ByteArray &src, size_t start) {
+	if (src._size + start>_size)
+		throw std::runtime_error(stdPrintf("Dimensione array da copiare %i troppo grande; dimensione massima %i", src._size + start, _size));
+	::memcpy_s(_data + start, _size - (start), src._data, src._size);
+}
+
+void ByteArray::rightcopy(const ByteArray &src, size_t end) {
+	if (src._size + end>_size)
+		throw std::runtime_error(stdPrintf("Dimensione array da copiare %i troppo grande; dimensione massima %i", src._size + end, _size));
+	::memcpy_s(_data + _size - end - src._size, (end + src._size), src._data, src._size);
+}
+
+ByteArray &ByteArray::fill(const uint8_t value) {
+	for (size_t i = 0; i<_size; i++)
+		_data[i] = value;
+	return *this;
+}
+
+ByteArray &ByteArray::random() {
+	RAND_bytes(_data, (int)_size);
+	return *this;
+}
+
+ByteArray &ByteArray::reverse() {
+	size_t dwHalfSize = _size >> 1;
+	uint8_t temp;
+	for (size_t i = 0; i<dwHalfSize; i++) {
+		temp = _data[i];
+		_data[i] = _data[_size - i - 1];
+		_data[_size - i - 1] = temp;
+	}
+	return *this;
+}
+
+ByteArray ByteArray::right(size_t size) const {
+
+	if (size>_size)
+		throw std::runtime_error("Array derivato troppo grande");
+	return(ByteArray(*this, _size - size, size ));
+
+}
+
+ByteArray ByteArray::left(size_t size) const {
+
+	if (size>_size)
+		throw std::runtime_error("Array derivato troppo grande");
+	return(ByteArray(*this, 0, size));
+
+}
+
+ByteArray ByteArray::mid(size_t start) const {
+	if (start >_size)
+		throw std::runtime_error("Array derivato troppo grande");
+	return(ByteArray(*this, start, _size - start));
+}
+
+ByteArray ByteArray::mid(size_t start, size_t size) const {
+	if (start + size>_size)
+		throw std::runtime_error("Array derivato troppo grande");
+	return(ByteArray(*this, start, size ));
+}
+
+ByteArray ByteArray::revmid(size_t toend) const {
+	if (toend >_size)
+		throw std::runtime_error("Array derivato troppo grande");
+	return(ByteArray(*this, 0, _size - toend));
+}
+
+ByteArray ByteArray::revmid(size_t toend, size_t size) const {
+	if (toend + size>_size)
+		throw std::runtime_error("Array derivato troppo grande");
+	return(ByteArray(*this, _size - toend - size, size ));
+}
+
+ByteArray::~ByteArray() {
+	_size = 0;
+	_data = nullptr;
+}
+
+ByteDynArray ByteArray::getASN1Tag(unsigned int tag) const {
+	
+	size_t tl = ASN1TLength(tag);
+	size_t ll = ASN1LLength(size());
+	ByteDynArray result(tl + ll + size());
+	putASN1Tag(tag, result);
+	putASN1Length(size(), result.mid(tl));
+	result.mid(tl + ll).copy(*this);
+	return result;
+}
+
+void ByteDynArray::alloc_copy(const ByteArray &src) {
+	clear();
+	_data = new uint8_t[src.size()];
+	_size = src.size();
+	copy(src);
+	return;
+}
+
+ByteDynArray::ByteDynArray()  {
+	_size = 0;
+	_data = nullptr;
+};
+
+ByteDynArray::ByteDynArray(const ByteDynArray &src) : ByteDynArray() {
+	alloc_copy(src);
+};
+
+ByteDynArray::ByteDynArray(const ByteArray &src) : ByteDynArray() {
+	alloc_copy(src);
+};
+
+ByteDynArray::ByteDynArray(const char *data) : ByteDynArray() {
+	readHexData(data, *this);
+}
+
+ByteDynArray::ByteDynArray(size_t size) {
+	_data = new uint8_t[size];
+	_size = size;
+
+};
+ByteDynArray::~ByteDynArray() {
+	clear();
+}
+
+ByteDynArray &ByteDynArray::operator = (const ByteDynArray &src) {
+	alloc_copy(src);
+	return *this;
+}
+
+void ByteDynArray::resize(size_t size, bool bKeepData) {
+	if (!bKeepData) {
+		clear();
+		_data = new uint8_t[size];
+		_size = size;
+	}
+	else {
+		uint8_t* pbtNewData = new uint8_t[size];
+		size_t dwMinSize = min(size, _size);
+		if (dwMinSize>0)
+			memcpy_s(pbtNewData, size, _data, dwMinSize);
+		clear();
+		_data = pbtNewData;
+		_size = size;
+	}
+}
+
+void ByteDynArray::clear() {
+	if (_data != nullptr)
+		delete[] _data;
+	_data = nullptr;
+	_size = 0;
+}
+
+ByteDynArray &ByteDynArray::append(const ByteArray &src) {
+	if (src.size()>0) {
+		resize(_size + src.size(), true);
+		rightcopy(src);
+	}
+	return *this;
+}
+
+ByteDynArray &ByteDynArray::push(const uint8_t data) {
+	resize(_size + 1, true);
+	_data[_size - 1] = data;
+	return *this;
+}
+
+uint8_t* ByteDynArray::detach() {
+	return _data;
+	_data = nullptr;
+	_size = 0;
+}
+bool ByteArray::indexOf(ByteArray &data,size_t &position) const {
+	if (data.size() == 0)
+		return 0;
+	if (_size < data.size())
+		return false;
+	size_t start = _size - data.size();
+	for (size_t i = 0; i <= start; i++) {
+		bool ok = true;
+		for (unsigned int j = 0; j < data.size(); j++) {
+			if (_data[i + j] != data[j]) {
+				ok = false;
+				break;
+			}
+		}
+		if (ok) {
+			position = i;
+			return true;
+		}
+	}
+	return false;
+}

--- a/CSP/Util/Array.h
+++ b/CSP/Util/Array.h
@@ -7,430 +7,122 @@
 #include <ctype.h>
 #include <openssl/rand.h>
 #include <type_traits>
+#include <stdexcept>
+#include <string>
+#include <cstdint>
 
 #ifndef min
 #define min(a,b) ((a)<(b)) ? (a) : (b)
 #endif
 
-char *err_string(const char *format,...);
-template <class T> class Array;
-void putASN1Tag(DWORD tag,Array<BYTE> &data);
-void putASN1Length(LONG len,Array<BYTE> &data);
-int ASN1TLength(DWORD tag);
-int ASN1LLength(LONG len);
-
+class ByteArray;
 class ByteDynArray;
-template <class T> class Array {
+
+std::string stdPrintf(const char *format, ...); 
+void putASN1Tag(unsigned int tag, ByteArray &data);
+void putASN1Length(size_t len, ByteArray &data);
+size_t ASN1TLength(unsigned int tag);
+size_t ASN1LLength(size_t len);
+
+class ByteArray {
+protected:
+	size_t _size;
+	uint8_t *_data;
 public:
-	// Array funziona correttamente solo con i TrivialType, perché usa memcpy, memcmp, ecc.
-	static_assert(std::is_trivial<T>::value, "T non è un TrivialType");
 
-	DWORD dwSize;
-	T *pbtData;
-
-	inline DWORD size() const {
-		return(dwSize);
-	}
-
-	Array() {
-		pbtData=NULL;
-		dwSize=0;
-	}
-
-	Array(T* data,DWORD size) {
-		pbtData=data;
-		dwSize=size;
-	}
-	Array(const Array<T>& ba,DWORD size,DWORD start=0) {
-		if (size==0xffffffff) size=ba.size()-start;
-		if (start+size>ba.size()) 
-			throw err_string("Array derivato troppo grande");
-		dwSize=size;
-		pbtData=ba.pbtData+start;
-	}
-
-	Array(const Array<T> &src) {
-		init_func_internal
-		dwSize=src.dwSize;
-		pbtData=src.pbtData;
-		exit_func_internal
-  	};
-  
-  	inline bool operator==(const Array<T> &src) const {
-  		init_func_internal
-  		if (dwSize!=src.dwSize)
-			return false;
-		return (memcmp(pbtData,src.pbtData,dwSize)==0);
-  		exit_func_internal
-	};
-
-	int atoi() {
-  		init_func_internal
-		int val=0;
-		for (DWORD i=0;i<dwSize;i++) {
-			if (val>(INT_MAX / 10))
-				throw err_string("owerflow");
-			val=(val*10)+pbtData[i]-'0';
-		}
-		return val;
-  		exit_func_internal
-	}
-  	inline bool operator<(const Array<T> &src) const {
-  		init_func_internal
-  		if (dwSize<src.dwSize)
-			return true;
-		return (memcmp(pbtData,src.pbtData,dwSize)<0);
-  		exit_func_internal
-	};
-
-  	inline bool operator>(const Array<T> &src) const {
-  		init_func_internal
-  		if (dwSize>src.dwSize)
-			return true;
-		return (memcmp(pbtData,src.pbtData,dwSize)>0);
-  		exit_func_internal
-	};
-
-	inline bool operator!=(const Array<T> &src) const {
-  		init_func_internal
-  		if (dwSize!=src.dwSize)
-  			return true;
-		return (memcmp(pbtData,src.pbtData,dwSize)!=0);
-  		return false;
-  		exit_func_internal
-	};
-
-	inline bool isEmpty() const {
-		return(dwSize==0);
+	ByteArray();
+	ByteArray(uint8_t* data, size_t size);
+	ByteArray(const ByteArray& ba, size_t start,size_t size);
+	ByteArray(const ByteArray& ba, size_t start);
+	ByteArray(const ByteArray &src);
+	bool operator==(const ByteArray &src) const;
+	bool operator<(const ByteArray &src) const;
+	bool operator>(const ByteArray &src) const;
+	bool operator!=(const ByteArray &src) const;
+	bool isEmpty() const {
+		return(_size == 0);
 	}
 
 	inline bool isNull() const {
-		return(pbtData==NULL);
+		return(_data == nullptr);
 	}
 
-	inline T *lock(DWORD size=0xffffffff,DWORD start=0) const {
-	#ifdef _BOUND_CHECK
-		init_func_internal
-		if (start<0) throw err_string("Lock dell'array al di fuori dei limiti; start %i",start);
-		if (size==0xffffffff) {
-			if (start==0) return pbtData;
-			else return pbtData+start;
-		}
-		else
-			if (size+start>dwSize) throw err_string("Lock dell'array al di fuori dei limiti; start %i, size %i, dimensione %i",start,size,dwSize);
-		return pbtData+start;
-		exit_func_internal
-	#else
-		return pbtData+start;
-	#endif
+	inline uint8_t *data() const  {
+		return _data;
 	}
 
-	inline T& operator[] (DWORD pos) const {
-		init_func_internal
-	#ifdef _BOUND_CHECK
-		if (pos>=dwSize) throw err_string("Accesso all'array alla posizione %i non consentito; dimensione massima %i",pos,dwSize);
-	#endif
-		return pbtData[pos];
-		exit_func_internal
-	}
-	inline T& at(DWORD pos) {
-		return((*this)[pos]);
+	inline uint8_t & operator[] (size_t pos) const{
+		if (pos >= _size) throw std::runtime_error(stdPrintf("Accesso all'array alla posizione %i non consentito; dimensione massima %i", pos, _size));
+		return _data[pos];
 	}
 
-	void *copy(const Array<T> &src,DWORD start=0) {
-		init_func_internal
-	#ifdef _BOUND_CHECK
-		if (src.dwSize+start>dwSize)
-			throw err_string("Dimensione array da copiare %i troppo grande; dimensione massima %i",src.dwSize+start,dwSize);
-	#endif
-		::memcpy_s(pbtData + start, dwSize - (start*sizeof(T)), src.pbtData, src.dwSize*sizeof(T));
-		return pbtData + start;
-		exit_func_internal
+	inline size_t size() const {
+		return(_size);
 	}
 
-	void *rightcopy(const Array<T> &src,DWORD end=0) {
-		init_func_internal
-	#ifdef _BOUND_CHECK
-		if (src.dwSize+end>dwSize)
-			throw err_string("Dimensione array da copiare %i troppo grande; dimensione massima %i",src.dwSize+end,dwSize);
-	#endif
-		::memcpy_s(pbtData + dwSize - end - src.dwSize, (end + src.dwSize)*sizeof(T), src.pbtData, src.dwSize*sizeof(T));
-		return pbtData + dwSize - end - src.dwSize;
-		exit_func_internal
-	}
+	void copy(const ByteArray &src, size_t start = 0);
+	void rightcopy(const ByteArray &src, size_t end = 0);
 
-	void *copy(const T *src,DWORD size,DWORD start=0) {
-		init_func_internal
-	#ifdef _BOUND_CHECK
-		if (size+start>dwSize) 
-			throw err_string("Dimensione array da copiare %i troppo grande; dimensione massima %i",size+start,dwSize);
-	#endif
-		::memcpy_s(pbtData + start, (dwSize - start) *sizeof(T), src, size*sizeof(T));
-		return pbtData + start;
-		exit_func_internal
-	}
+	ByteArray &fill(const uint8_t value);
+	ByteArray &random();
+	ByteArray &reverse();
 
-	void *rightcopy(const T *src,DWORD size,DWORD end=0) {
-		init_func_internal
-	#ifdef _BOUND_CHECK
-		if (size+end>dwSize) 
-			throw err_string("Dimensione array da copiare %i troppo grande; dimensione massima %i",size+end,dwSize);
-	#endif
-		::memcpy_s(pbtData + dwSize - end - size, (end + size)*sizeof(T),src, size*sizeof(T));
-		return pbtData + dwSize - end - size;
-		exit_func_internal
-	}
+	ByteArray right(size_t size) const;
+	ByteArray left(size_t size) const;
+	ByteArray mid(size_t start) const;
+	ByteArray mid(size_t start, size_t size) const;
+	ByteArray revmid(size_t toend) const;
+	ByteArray revmid(size_t toend, size_t size) const;
+	bool indexOf(ByteArray &data, size_t &position) const;
 
-	void fill(const T &value) {
-		init_func_internal
-  		for (DWORD i=0;i<dwSize;i++)
-			pbtData[i]=value;
-		exit_func_internal
-	}
-
-	Array<T> &random() {
-		RAND_bytes(pbtData, dwSize);
-		//for (DWORD i = 0; i<dwSize; i++)
-		//	pbtData[i] = rand() % 256;
-		return *this;
-	}
-
-	Array<T> &reverse() {
-  		DWORD dwHalfSize=dwSize>>1;
-  		T temp;
-  		for (DWORD i=0;i<dwHalfSize;i++) {
-  			temp=pbtData[i];
-  			pbtData[i]=pbtData[dwSize-i-1];
-  			pbtData[dwSize-i-1]=temp;
-  		}
-		return *this;
-  	}
-
-	Array<T> right(DWORD size) const {
-		init_func_internal
-		if (size>dwSize) 
-			throw err_string("Array derivato troppo grande");
-		return(Array<T>(*this,size,dwSize-size));
-		exit_func_internal
-	}
-
-	Array<T> left(DWORD size) const {
-		init_func_internal
-		if (size>dwSize) 
-			throw err_string("Array derivato troppo grande");
-		return(Array<T>(*this,size));
-		exit_func_internal
-	}
-
-	Array<T> mid(DWORD start,DWORD size=0xffffffff) const {
-		init_func_internal
-		if (size==0xffffffff) size=dwSize-start;
-		if (start+size>dwSize) 
-			throw err_string("Array derivato troppo grande");
-		return(Array<T>(*this,size,start));
-		exit_func_internal
-	}
-
-	Array<T> revmid(DWORD toend,DWORD size=0xffffffff) const {
-		init_func_internal
-		if (size==0xffffffff) size=dwSize-toend;
-		if (toend+size>dwSize) 
-			throw err_string("Array derivato troppo grande");
-		return(Array<T>(*this,size,dwSize-toend-size));
-		exit_func_internal
-	}
-
-	virtual ~Array() {
-		dwSize=0;
-		pbtData=NULL;
-	}
-
-	ByteDynArray &setASN1Tag(int tag, ByteDynArray &result) {
-		int tl=ASN1TLength(tag);
-		int ll=ASN1LLength(size());
-		result.resize(tl+ll+size());
-		putASN1Tag(tag,result);
-		putASN1Length(size(),result.mid(tl));
-		result.mid(tl+ll).copy(*this);
-		return result;
-	}
+	int atoi() const;
+	ByteDynArray getASN1Tag(unsigned int tag) const;
+	
+	virtual ~ByteArray();
 };
 
-typedef Array<BYTE> ByteArray;
+void readHexData(const char *data, ByteDynArray &ba);
+size_t countHexData(const char *data);
+size_t setHexData(const char *data, uint8_t *buf);
 
-template <class T> class DynArray : public Array<T>
+class ByteDynArray : public ByteArray
 {
+	void alloc_copy(const ByteArray &src);
+
 public:
-	static_assert(std::is_nothrow_destructible<T>::value, "Il distruttore di T può sollevare eccezioni");
+	ByteDynArray();
+	ByteDynArray(const ByteArray &src);
+	ByteDynArray(const ByteDynArray &src);
+	ByteDynArray(size_t size);
+	ByteDynArray(const char *hexData);
+	ByteDynArray(ByteDynArray &&src);
 
-	DynArray()  { 
-		dwSize=0;
-		pbtData=NULL;
-	};
-	DynArray(const Array<T> &src) {
-		init_func_internal
-		dwSize=0;
-		pbtData=NULL;
-		alloc_copy(src);
-		exit_func_internal
-	};
-	DynArray(const DynArray<T> &src) {
-		init_func_internal
-		dwSize=0;
-		pbtData=NULL;
-		alloc_copy(src);
-		exit_func_internal
-	};
-	DynArray(const T *src,DWORD size) {
-		init_func_internal
-		pbtData=new T[size];
-		dwSize = size;
-		copy(src,size);
-		exit_func_internal
-	}
-	DynArray(DWORD size) {
-		init_func_internal
-		pbtData=new T[size];
-		dwSize=size;
-		exit_func_internal
-	};
-	~DynArray() {
-		delete[] pbtData;
-	}
-	DynArray<T> &operator=(const DynArray<T> src) {
-		init_func_internal
-		alloc_copy(src);
-		return *this;
-		exit_func_internal
-	}
+	~ByteDynArray();
+	ByteDynArray &operator=(const ByteDynArray &src);
+	ByteDynArray &operator=(ByteDynArray &&src);
 
-	void resize(DWORD size,bool bKeepData=false) {
-		init_func_internal
-		if (!bKeepData) {
-			clear();
-			pbtData = new T[size];
-			dwSize=size;
-		}
-		else {
-			T* pbtNewData=new T[size];
-			DWORD dwMinSize=min(size,dwSize);
-			if (dwMinSize>0)
-				memcpy_s(pbtNewData, sizeof(T)*size, pbtData, sizeof(T)*dwMinSize);
-			clear();
-			pbtData=pbtNewData;
-			dwSize=size;
-		}
-		exit_func_internal
-	}
-	void clear() {
-		init_func_internal
-		delete[] pbtData;
-		pbtData=NULL;
-		dwSize=0;
-		exit_func_internal
-	}
-	void alloc_copy(const Array<T> &src) {
-		init_func_internal
-		clear();
-		pbtData = new T[src.dwSize];
-		dwSize=src.dwSize;
-		copy(src);
-		return;
-		exit_func_internal
-	}
-	void alloc_copy(const T *src,DWORD size) {
-		init_func_internal
-		clear();
-		pbtData = new T[size];
-		dwSize=size;
-		copy(src,size);
-		return;
-		exit_func_internal
-	}
-	DynArray<T> & append(const Array<T> &src) {
-		if (src.dwSize>0) {
-			resize(dwSize+src.dwSize,true);
-			rightcopy(src);
-		}
-		return *this;
-	}
-	DynArray<T> & random(int size) {
-		resize(size,false);
-		RAND_bytes(pbtData, size);
-		//for (int i=0;i<size;i++)
-		//	pbtData[i]=rand()%256;
-		return *this;
-	}
-
-	DynArray<T> & push(const T data) {
-		resize(dwSize+sizeof(T),true);
-		pbtData[dwSize-1]=data;
-		return *this;
-	}
-
-	T* detach() {
-		return pbtData;
-		pbtData = nullptr;
-		dwSize = 0;
-	}
-	int IndexOf(Array<T> data) {
-		if (data.size() == 0)
-			return 0;
-		if (dwSize < data.size())
-			return -1;
-		int start = dwSize - data.size();
-		for (int i = 0; i <= start; i++) {
-			bool ok = true;
-			for (unsigned int j = 0; j < data.size(); j++) {
-				if (pbtData[i + j] != data.pbtData[j]) {
-					ok = false;
-					break;
-				}
-			}
-			if (ok)
-				return i;
-		}
-		return -1;
-	}
-};
-
-void readHexData(const char *data,ByteDynArray &ba);
-DWORD countHexData(const char *data);
-DWORD setHexData(const char *data,BYTE *buf);
-
-// TODO: ByteDynArray migliorerebbe se usassi la
-// Named Return Value Optimization piuttosto che ritornare 
-// i risultati per riferimento
-class ByteDynArray : public DynArray<BYTE> {
-public:
-	ByteDynArray(const char *data) {
-		readHexData(data,*this);
-	}
-	ByteDynArray(BYTE* src,int len) : DynArray<BYTE>(src,len) {}
-	ByteDynArray(int len) : DynArray<BYTE>(len) {}
-	ByteDynArray() : DynArray<BYTE>() {}
-	ByteDynArray(const ByteArray &ba) : DynArray<BYTE>(ba) {}
-	ByteDynArray& init(const char *data) {
-		readHexData(data,*this);
-		return *this;
-	}
+	void resize(size_t size, bool bKeepData = false);
+	void clear();
+	ByteDynArray &append(const ByteArray &src);
+	ByteDynArray &push(const uint8_t data);
+	uint8_t* detach();
 
 private:
-	size_t internalSet(ByteArray* ba, BYTE data) {
-		if (ba != NULL)
+	size_t internalSet(ByteArray* ba, uint8_t data) {
+		if (ba != nullptr)
 			(*ba)[0] = data;
 		return 1;
 	}
 
 	size_t internalSet(ByteArray* ba, ByteArray *data) {
-		if (ba != NULL)
+		if (ba != nullptr)
 			ba->copy(*data);
 		return data->size();
 	}
 
 	size_t internalSet(ByteArray* ba, const char *data) {
-		if (ba != NULL)
-			return setHexData(data, ba->lock());
+		if (ba != nullptr)
+			return setHexData(data, ba->data());
 		return countHexData(data);
 	}
 
@@ -441,10 +133,10 @@ private:
 public:
 	template<typename Arg0, typename ... Args>
 	ByteDynArray& set(Arg0 &&arg0, Args &&... args) {
-		size_t totSize = internalSet((ByteArray*)NULL, std::forward<Arg0>(arg0));
+		size_t totSize = internalSet((ByteArray*)nullptr, std::forward<Arg0>(arg0));
 
 		size_t totSize2 = 0;
-		int dummy[] = { 0, ((void)(totSize2 += internalSet((ByteArray*)NULL, std::forward<Args>(args))), 0) ... };
+		int dummy[] = { 0, ((void)(totSize2 += internalSet((ByteArray*)nullptr, std::forward<Args>(args))), 0) ... };
 
 		resize(totSize + totSize2);
 
@@ -455,148 +147,31 @@ public:
 		return *this;
 	}
 
-  ByteDynArray &setASN1Tag(int tag,ByteArray &content) {
-		int tl=ASN1TLength(tag);
-		int ll=ASN1LLength(content.size());
-		resize(tl+ll+content.size());
-		putASN1Tag(tag,*this);
-		putASN1Length(content.size(),mid(tl));
-		mid(tl+ll).copy(content);
+	ByteDynArray &setASN1Tag(unsigned int tag, ByteArray &content) {
+		size_t tl = ASN1TLength(tag);
+		size_t ll = ASN1LLength(content.size());
+		resize(tl + ll + content.size());
+		putASN1Tag(tag, *this);
+		putASN1Length(content.size(), mid(tl));
+		mid(tl + ll).copy(content);
 		return *this;
 	}
 	void load(const char *fname) {
 		FILE *fl = nullptr;
 		fopen_s(&fl, fname, "rb");
 		if (fl == nullptr)
-			throw err_string("Il file non esiste");
+			throw std::runtime_error("Il file non esiste");
 		fseek(fl, 0, SEEK_END);
 		resize(ftell(fl), false);
 		fseek(fl, 0, SEEK_SET);
-		fread_s(pbtData, dwSize, 1, dwSize, fl);
+		fread_s(_data, _size, 1, _size, fl);
 		fclose(fl);
 	}
 };
 
-#define ASN1Tag(tag,content) ByteDynArray().setASN1Tag(tag,content)
-
-typedef DynArray<char> CharDynArray;
-class Stringa : public CharDynArray
-{
-public:
-	Stringa() : CharDynArray() {};
-	Stringa(const char *src) {
-		init_func_internal
-			alloc_copy(src);
-		exit_func_internal
-	};
-
-	Stringa(const BYTE *src, DWORD size) {
-		init_func_internal
-			clear();
-		pbtData = new char[size + 1];
-		dwSize = size + 1;
-		fill(0);
-		copy((char *)src, size);
-		exit_func_internal
-	};
-
-	Stringa(const CharDynArray &src) : CharDynArray(src) {};
-	Stringa(DWORD size) : CharDynArray(size) {};
-
-	inline bool operator<(const Stringa &op) const  {
-		return(memcmp(pbtData, op.pbtData, min(dwSize, op.dwSize)) < 0);
-	}
-
-	inline bool operator>(const Stringa &op) const  {
-		return(memcmp(pbtData, op.pbtData, min(dwSize, op.dwSize)) > 0);
-	}
-
-	inline bool operator==(const char *op) const  {
-		DWORD dwOpSize = (DWORD)::strnlen(op, dwSize + 1) + 1;
-		if (dwSize != dwOpSize) return(false);
-		return(memcmp(pbtData, op, dwSize) == 0);
-	}
-
-	inline bool operator!=(const char *op) const  {
-		DWORD dwOpSize = (DWORD)::strnlen(op, dwSize + 1) + 1;
-		if (dwSize != dwOpSize) return(false);
-		return(memcmp(pbtData, op, dwSize) != 0);
-	}
-
-	inline bool operator==(const Stringa &op) const  {
-		if (dwSize != op.dwSize) return(false);
-		return(memcmp(pbtData, op.pbtData, dwSize) == 0);
-	}
-
-	void alloc_copy(const char *str) {
-		init_func_internal
-			clear();
-		if (str == 0)
-			return;
-		size_t size = ::strlen(str) + 1;
-		pbtData = new char[size];
-		dwSize = size;
-		copy(str, dwSize);
-		exit_func_internal
-	}
-
-	DWORD readFile(char * path) {
-		FILE *f = nullptr;
-		fopen_s(&f, path, "rb");
-		if (f == nullptr)
-			throw err_string("Errore in lettura file %s", path);
-		fseek(f, 0, SEEK_END);
-		int len = ftell(f);
-		fseek(f, 0, SEEK_SET);
-		resize(len + 1,false);
-		pbtData[len] = 0;
-		fread(pbtData, 1, len, f);
-		fclose(f);
-		return 0;
-	}
-
-	DWORD strlen() const {
-		init_func_internal
-		auto len = ::strnlen(pbtData, dwSize + 1);
-		if (len == (dwSize + 1))
-			throw err_string("Stringa non valida, fine stringa non trovato");
-		return (DWORD)len;
-		exit_func_internal
-	}
-
-	inline char *stringlock() {
-		return (char*)lock();
-		//return(lock((DWORD)strlen()+1));
-	}
-
-	Stringa &printf(const char *format,...) {
-		init_func_internal
-		va_list params;
-		va_start (params, format);
-		resize(_vscprintf(format, params)+1);
-		vsprintf_s(pbtData,dwSize,format, params);
-		va_end(params);
-		return *this;
-		exit_func_internal
-	}
-
-	void printfList(const char *format,va_list params) {
-		init_func_internal
-		resize(_vscprintf(format, params)+1);
-		vsprintf_s(pbtData,dwSize,format, params);
-		exit_func_internal
-	}
-
-	ByteArray toByteArray() {
-		init_func_internal
-		return ByteArray((BYTE*)pbtData,dwSize-1);
-		exit_func_internal
-	}
-
-};	
-
-#define StringToByteArray(a) (ByteArray((BYTE*)(a),sizeof(a)-1))
-#define S2B(a) (ByteArray((BYTE*)(a),sizeof(a)-1))
-#define VarToByteArray(a) (ByteArray((BYTE*)&(a),sizeof(a)))
-#define ByteArrayToVar(a,b) (*(b*)(a).lock(sizeof(b)))
+#define StringToByteArray(a) (ByteArray((uint8_t*)(a),sizeof(a)-1))
+#define S2B(a) (ByteArray((uint8_t*)(a),sizeof(a)-1))
+#define VarToByteArray(a) (ByteArray((uint8_t*)&(a),sizeof(a)))
+#define VarToByteDynArray(a) (ByteDynArray(VarToByteArray(a)))
+#define ByteArrayToVar(a,b) (*(b*)(a).data())
 

--- a/CSP/Util/IniSettings.cpp
+++ b/CSP/Util/IniSettings.cpp
@@ -8,7 +8,7 @@ std::vector<IniSettings*> _iniSettings;
 void GetIniString(const char *fileName, const char* section, const char* name, std::string &buf) {
 	buf.resize(100);
 	while (true) {
-		DWORD size=GetPrivateProfileStringA(section,name,"",&buf[0],buf.size(),fileName);
+		DWORD size=GetPrivateProfileStringA(section,name,"",&buf[0],(DWORD)buf.size(),fileName);
 		if (size<(buf.size()-2)) {
 			buf.resize(size+1,true);
 			return;
@@ -138,6 +138,6 @@ extern "C" {
 		std::string res = out + out2;
 		if (data!=NULL) 
 			memcpy_s(data,res.size(),res.c_str(),res.size());
-		return res.size();
+		return (int)res.size();
 	}
 }

--- a/CSP/Util/SyncroEvent.cpp
+++ b/CSP/Util/SyncroEvent.cpp
@@ -27,7 +27,7 @@ CSyncroEvent::CSyncroEvent(const char *szName)
 			SECURITY_DESCRIPTOR secDesc;
 			DWORD dwACL=sizeof(ACL)+sizeof(ACCESS_ALLOWED_ACE)+sizeof(SID);
 			ByteDynArray pbtACL(dwACL);
-			PACL pACL=(PACL)pbtACL.lock();
+			PACL pACL=(PACL)pbtACL.data();
 
 			InitializeAcl(pACL,dwACL,ACL_REVISION);
 			PSID pSid;

--- a/CSP/Util/SyncroMutex.cpp
+++ b/CSP/Util/SyncroMutex.cpp
@@ -28,7 +28,7 @@ void CSyncroMutex::Create(const char *szName)
 			SECURITY_DESCRIPTOR secDesc;
 			DWORD dwACL=sizeof(ACL)+sizeof(ACCESS_ALLOWED_ACE)+sizeof(SID);
 			ByteDynArray pbtACL(dwACL);
-			PACL pACL=(PACL)pbtACL.lock();
+			PACL pACL=(PACL)pbtACL.data();
 
 			InitializeAcl(pACL,dwACL,ACL_REVISION);
 			PSID pSid;

--- a/CSP/Util/TLV.h
+++ b/CSP/Util/TLV.h
@@ -2,8 +2,8 @@
 #include "Array.h"
 #include <map>
 
-typedef std::map<BYTE,ByteArray> tlvMap;
-typedef std::map<BYTE, ByteDynArray> tlvCreateMap;
+typedef std::map<uint8_t, ByteArray> tlvMap;
+typedef std::map<uint8_t, ByteDynArray> tlvCreateMap;
 
 class  CTLV
 {
@@ -11,8 +11,8 @@ class  CTLV
 public:
 	CTLV(ByteArray &data);
 	~CTLV(void);
-	RESULT getValue(BYTE Tag,ByteArray &Value);
-	RESULT getTAG(BYTE Tag,ByteArray *&Value);
+	RESULT getValue(uint8_t Tag, ByteArray &Value);
+	RESULT getTAG(uint8_t Tag, ByteArray *&Value);
 };
 
 class  CTLVCreate
@@ -22,8 +22,8 @@ public:
 
 	CTLVCreate(void);
 	~CTLVCreate(void);
-	RESULT addValue(BYTE Tag,ByteDynArray *&Value);
-	RESULT getValue(BYTE Tag,ByteDynArray *&Value);
-	RESULT setValue(BYTE Tag,ByteArray &Value);
+	RESULT addValue(uint8_t Tag, ByteDynArray *&Value);
+	RESULT getValue(uint8_t Tag, ByteDynArray *&Value);
+	RESULT setValue(uint8_t Tag, ByteArray &Value);
 	RESULT getBuffer(ByteDynArray &Value);
 };

--- a/CSP/Util/UtilException.cpp
+++ b/CSP/Util/UtilException.cpp
@@ -74,7 +74,7 @@ void CBaseException::DumpTree(std::string &dump)
 		if (!exc->fileName.empty())
 			pos = exc->fileName.append("(").append(std::to_string(exc->line)).append(")");
 		const char *exName=exc->ExceptionName();
-		int sz=dump.size()-1;
+		size_t sz=dump.size()-1;
 		dump = pos.append(" : ").append(exName).append(desc).append("\n");
 		exc=exc->innerException.get();
 	}

--- a/CSP/Util/defines.h
+++ b/CSP/Util/defines.h
@@ -3,7 +3,6 @@
 #define OK 0
 #define FAIL ((DWORD)0xFFFFFFFF)
 typedef unsigned long RESULT;
-typedef unsigned char BYTE;
 
 #define ERR_CARD_FILE_DEACTIVATED		0x6283
 #define ERR_CARD_FILE_TERMINATED		0x6285
@@ -60,10 +59,10 @@ typedef unsigned char BYTE;
 #define exit_func_internal \
 	} \
 	catch(const char *ex) { \
-		throw err_string("Eccezione in %s:%s",_this_func_name,ex); \
+		throw std::runtime_error(stdPrintf("Eccezione in %s:%s",_this_func_name,ex)); \
 	} \
 	catch(...) { \
-		throw err_string("Errore in %s",_this_func_name); \
+		throw std::runtime_error(stdPrintf("Errore in %s",_this_func_name)); \
 	}
 
 

--- a/CSP/Util/defines_err.h
+++ b/CSP/Util/defines_err.h
@@ -82,4 +82,5 @@ if ((_call_ris=(call))!=CARD_OK) { \
 
 
 #define ER_ASSERT(a,b) \
-	if (!(a)) throw CStringException(__LINE__,__FILE__,b);
+	if (!(a)) \
+		throw CStringException(__LINE__,__FILE__,b);

--- a/CSP/Util/funccallinfo.h
+++ b/CSP/Util/funccallinfo.h
@@ -4,7 +4,7 @@
 
 class  CFuncCallInfo {
 	char *fName;
-	DWORD dwLogNum;
+	unsigned int LogNum;
 	CLog &log;
 public:
 	CFuncCallInfo(char *name,CLog &logInfo);
@@ -12,26 +12,34 @@ public:
 
 	static void startCall();
 	
-	void logRet(DWORD val,DWORD line);
-	void logRet(char *val,DWORD line);
-	void logRet(BOOL val,DWORD line);
-	void logRet(void *val,DWORD line);
-	void logRet(DWORD line);
-	void logRet(ByteArray &val,DWORD line);
+	void logRet(DWORD val, unsigned int line);
+	void logRet(char *val, unsigned int line);
+	void logRet(BOOL val, unsigned int line);
+	void logRet(void *val, unsigned int line);
+	void logRet(unsigned int line);
+	void logRet(ByteArray &val, unsigned int line);
 	void logRet();
 
 	void logParameter(DWORD val);
 	void logParameter(DWORD *val);
 	void logParameter(void *val);
 	void logParameter(char *val);
-	void logParameter(char *val,DWORD len);
-	void logParameter(void *val,DWORD len);
-	void logParameter(char *val,DWORD *len);
-	void logParameter(void *val,DWORD *len);
-	void logParameterHide(char *val,DWORD len);
-	void logParameterHide(void *val,DWORD len);
-	void logParameterHide(char *val,DWORD *len);
-	void logParameterHide(void *val,DWORD *len);
+	void logParameter(unsigned char *val, size_t len);
+	void logParameter(char *val, size_t len);
+	void logParameter(void *val, size_t len);
+	void logParameter(unsigned char *val, size_t *len);
+	void logParameter(char *val, size_t *len);
+	void logParameter(void *val, size_t *len);
+	void logParameter(unsigned char *val, unsigned long len);
+	void logParameter(char *val, unsigned long len);
+	void logParameter(void *val, unsigned long len);
+	void logParameter(unsigned char *val, unsigned long *len);
+	void logParameter(char *val, unsigned long *len);
+	void logParameter(void *val, unsigned long *len);
+	void logParameterHide(char *val, size_t len);
+	void logParameterHide(void *val, size_t len);
+	void logParameterHide(char *val, size_t *len);
+	void logParameterHide(void *val, size_t *len);
 };
 
 #define logParam(a) info.logParameter(a);

--- a/CSP/Util/log.h
+++ b/CSP/Util/log.h
@@ -15,19 +15,19 @@ struct _ATL_SYMBOL_INFO
 
 class CLog {
 public:
-	DWORD dwLogCount;
-	bool bInitialized;
-	bool bEnabled;
-	bool bFunctionLog;
-	bool bLogParam;
-	DWORD dwModuleNum;
+	unsigned int LogCount;
+	bool Initialized;
+	bool Enabled;
+	bool FunctionLog;
+	bool LogParam;
+	unsigned int ModuleNum;
 	std::string logDir;
 	std::string logPath;
 	std::string logName;
 	std::string logFileName;
 	std::string::iterator threadPos;
 	std::string logVersion;
-	bool bFirstLog;
+	bool FirstLog;
 
 	bool _stack_logged;
 
@@ -35,8 +35,8 @@ public:
 	~CLog(void);
 	DWORD write(const char *format,...);
 	void writePure(const char *format,...);
-	void writeBinData(BYTE *data,int datalen);
-	void initModule(const char *name,char *version);
+	void writeBinData(uint8_t *data, size_t datalen);
+	void initModule(const char *name,const char *version);
 	void initParam(CLog &log);
 	void writeModuleInfo();
 	void dumpErr();

--- a/CSP/Util/util.cpp
+++ b/CSP/Util/util.cpp
@@ -33,14 +33,14 @@ bool ishexdigit(char c) {
 	return false;
 }
 
-DWORD countHexData(const char *data)
+size_t countHexData(const char *data)
 {
-	DWORD cnt=0;
+	size_t cnt = 0;
 	size_t slen=strlen(data);
 	for (size_t i=0;i<slen;i++) {
 		if (isspace(data[i]) || data[i]==',') continue;
 		if (!isxdigit(data[i])) {
-			throw  CStringException("%s","Carattere non valido");
+			throw  std::runtime_error("Carattere non valido");
 		}
 
 		if ((i<slen-3) && data[i]=='0' && data[i+3]=='h')
@@ -58,7 +58,7 @@ DWORD countHexData(const char *data)
 				v|=hex2byte(data[i]);
 			}
 			else if (!isspace(data[i]))
-				throw  CStringException("%s","richiesto spazio");
+				throw  std::runtime_error("richiesto spazio");
 		}
 		cnt++;
 
@@ -68,14 +68,14 @@ DWORD countHexData(const char *data)
 	return cnt;
 }
 
-DWORD setHexData(const char *data,BYTE *buf)
+size_t setHexData(const char *data, uint8_t *buf)
 {
-	DWORD cnt=0;
+	size_t cnt = 0;
 	size_t slen=strlen(data);
 	for (size_t i=0;i<slen;i++) {
 		if (isspace(data[i]) || data[i]==',') continue;
 		if (!isxdigit(data[i])) {
-			throw  CStringException("%s","Carattere non valido");
+			throw  std::runtime_error("Carattere non valido");
 		}
 
 		if ((i<slen-3) && data[i]=='0' && data[i+3]=='h')
@@ -93,7 +93,7 @@ DWORD setHexData(const char *data,BYTE *buf)
 				v|=hex2byte(data[i]);
 			}
 			else if (!isspace(data[i]))
-				throw  CStringException("%s","richiesto spazio");
+				throw  std::runtime_error("richiesto spazio");
 		}
 		buf[0]=v;
 		buf++;
@@ -107,14 +107,14 @@ DWORD setHexData(const char *data,BYTE *buf)
 
 void readHexData(const char *data,ByteDynArray &ba)
 {
-	std::vector<BYTE> dt;
+	std::vector<uint8_t> dt;
 
 
 	size_t slen=strlen(data);
 	for (size_t i=0;i<slen;i++) {
 		if (isspace(data[i]) || data[i]==',') continue;
 		if (!isxdigit(data[i])) {
-			throw  CStringException("%s","Carattere non valido");
+			throw  std::runtime_error("Carattere non valido");
 		}
 
 		if ((i<slen-3) && data[i]=='0' && data[i+3]=='h')
@@ -132,7 +132,7 @@ void readHexData(const char *data,ByteDynArray &ba)
 				v|=hex2byte(data[i]);
 			}
 			else if (!isspace(data[i]))
-				throw  CStringException("%s","richiesto spazio");
+				throw  std::runtime_error("richiesto spazio");
 		}
 		dt.push_back(v);
 
@@ -140,13 +140,13 @@ void readHexData(const char *data,ByteDynArray &ba)
 			i++;
 	}
 
-	if (dt.size())
-		ba.alloc_copy(&dt[0],(DWORD)dt.size());
+	if (dt.size()>0)
+		ba = ByteArray(&dt[0], dt.size());
 	else 
 		ba.clear();
 }
 
-std::string HexByte(BYTE data, bool uppercase) {
+std::string HexByte(uint8_t data, bool uppercase) {
 	std::stringstream dmp;
 	dmp << std::hex << std::setfill('0');
 	if (uppercase)
@@ -167,7 +167,7 @@ std::string &dumpHexData(ByteArray &data, std::string &dump, bool withSpace, boo
 	dmp << std::hex << std::setfill('0');
 	if (uppercase)
 		dmp << std::uppercase;
-	for (DWORD i = 0; i<data.size(); i++) {
+	for (size_t i = 0; i<data.size(); i++) {
 		dmp << std::setw(2) << static_cast<unsigned>(data[i]);
 		if (withSpace)
 			dmp << " ";
@@ -187,23 +187,23 @@ std::string &dumpHexDataLowerCase(ByteArray &data, std::string &dump)
 	return dumpHexData(data, dump, false, false);
 }
 
-void PutPaddingBT0(ByteArray &ba,DWORD dwLen)
+void PutPaddingBT0(ByteArray &ba, size_t dwLen)
 {
 	init_func
 
 	if (dwLen>ba.size())
-		throw CStringException("Lunghezza del padding errata");
+		throw std::runtime_error("Lunghezza del padding errata");
 
 	ba.left(ba.size()-dwLen).fill(0);
 	exit_func
 }
 
 
-void PutPaddingBT1(ByteArray &ba,DWORD dwLen)
+void PutPaddingBT1(ByteArray &ba, size_t dwLen)
 {
 	init_func
 	if (dwLen>ba.size()-3)
-		throw CStringException("Lunghezza del padding errata");
+		throw std::runtime_error("Lunghezza del padding errata");
 
 	ba[0]=0;
 	ba[1]=1;
@@ -212,89 +212,84 @@ void PutPaddingBT1(ByteArray &ba,DWORD dwLen)
 	exit_func
 }
 
-void PutPaddingBT2(ByteArray &ba,DWORD dwLen)
+void PutPaddingBT2(ByteArray &ba, size_t dwLen)
 {
 	init_func
 	if (dwLen>ba.size()-3)
-		throw CStringException("Lunghezza del padding errata");
+		throw std::runtime_error("Lunghezza del padding errata");
 
 	ba[0]=0;
 	ba[1]=2;
-	for (DWORD i=2;i<ba.size()-dwLen;i++) {
-		BYTE b=0;
-		while (b==0)
-			b=rand()%0x100;
-		ba[i]=b;
-	}
-	ba[ba.size()-dwLen-1]=0;
+	ba.mid(2, ba.size() - dwLen - 3).random();
+	ba[ba.size() - dwLen - 1] = 0;
 	exit_func
 }
 
-DWORD RemoveSha1(ByteArray &paddedData) {
-	static BYTE SHA1Algo[] = { 0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a, 0x05, 0x00, 0x04, 0x14 };
+size_t RemoveSha1(ByteArray &paddedData) {
+	static uint8_t SHA1Algo[] = { 0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a, 0x05, 0x00, 0x04, 0x14 };
 	if (paddedData.left(sizeof(SHA1Algo)) == VarToByteArray(SHA1Algo))
 		return sizeof(SHA1Algo);
-	throw CStringException("OID Algoritmo SHA1 non presente");
+	throw std::runtime_error("OID Algoritmo SHA1 non presente");
 }
 
-DWORD RemoveSha256(ByteArray &paddedData) {
-	static BYTE SHA256Algo[] = { 0x30, 0x31, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20 };
+size_t RemoveSha256(ByteArray &paddedData) {
+	static uint8_t SHA256Algo[] = { 0x30, 0x31, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20 };
 	if (paddedData.left(sizeof(SHA256Algo)) == VarToByteArray(SHA256Algo))
 		return sizeof(SHA256Algo);
-	throw CStringException("OID Algoritmo SHA256 non presente");
+	throw std::runtime_error("OID Algoritmo SHA256 non presente");
 }
 
-DWORD RemovePaddingBT1(ByteArray &paddedData)
+size_t RemovePaddingBT1(ByteArray &paddedData)
 {
 	init_func
 	if (paddedData[0]!=0)
-		throw CStringException("Errore nel padding");
+		throw std::runtime_error("Errore nel padding");
 	if (paddedData[1]!=1)
-		throw CStringException("Errore nel padding");
-	for (DWORD i=2;i<paddedData.size();i++) {
+		throw std::runtime_error("Errore nel padding");
+	for (size_t i = 2; i<paddedData.size(); i++) {
 		if (paddedData[i]==0) {
 			return i+1;
 		}
 		if (paddedData[i]!=0xff)
-			throw CStringException("Errore nel padding");
+			throw std::runtime_error("Errore nel padding");
 	}
-	throw CStringException("Errore nel padding");
+	throw std::runtime_error("Errore nel padding");
 	exit_func
 }
 
-DWORD RemovePaddingBT2(ByteArray &paddedData)
+size_t RemovePaddingBT2(ByteArray &paddedData)
 {
 	init_func
 	if (paddedData[0]!=0)
-		throw CStringException("Errore nel padding");
+		throw std::runtime_error("Errore nel padding");
 	if (paddedData[1]!=2)
-		throw CStringException("Errore nel padding");
-	for (DWORD i=2;i<paddedData.size();i++)
+		throw std::runtime_error("Errore nel padding");
+	for (size_t i = 2; i<paddedData.size(); i++)
 		if (paddedData[i]==0) {
 			return i+1;
 		}
-	throw CStringException("Errore nel padding");
+	throw std::runtime_error("Errore nel padding");
 	exit_func
 }
 
-DWORD RemoveISOPad(ByteArray &paddedData)
+size_t RemoveISOPad(ByteArray &paddedData)
 {
 	init_func
-	for (int i=paddedData.size()-1;i>=0;i--) {
+		for (size_t i = paddedData.size() - 1; i >= 0; i--) {
 		if (paddedData[i]!=0) {
 			if (paddedData[i]!=0x80) {
-				throw CStringException("Errore nel padding");
+				throw std::runtime_error("Errore nel padding");
 			}
 			else {
 				return i;
 			}
 		}
 	}
-	throw CStringException("Errore nel padding");
+	throw std::runtime_error("Errore nel padding");
 	exit_func
 }
 
-DWORD ANSIPadLen(DWORD Len)
+size_t ANSIPadLen(size_t Len)
 {
 	if ((Len & 0x7) == 0)
 		return(Len);
@@ -302,7 +297,7 @@ DWORD ANSIPadLen(DWORD Len)
 		return(Len - (Len & 0x7) + 0x08);
 }
 
-void ANSIPad(ByteArray &Data,DWORD DataLen)
+void ANSIPad(ByteArray &Data, size_t DataLen)
 {
 	init_func
 	Data.mid(DataLen).fill(0);
@@ -310,7 +305,7 @@ void ANSIPad(ByteArray &Data,DWORD DataLen)
 
 }
 
-DWORD ISOPadLen16(DWORD Len)
+size_t ISOPadLen16(size_t Len)
 {
 	if ((Len & 0x10f) == 0)
 		return(Len + 16);
@@ -318,7 +313,7 @@ DWORD ISOPadLen16(DWORD Len)
 		return(Len - (Len & 0x0f) + 0x10);
 }
 
-DWORD ISOPadLen(DWORD Len)
+size_t ISOPadLen(size_t Len)
 {
 	if ((Len & 0x7) == 0)
 		return(Len+8);
@@ -326,7 +321,7 @@ DWORD ISOPadLen(DWORD Len)
 		return(Len - (Len & 0x7) + 0x08);
 }
 
-void ISOPad(const ByteArray &Data,DWORD DataLen)
+void ISOPad(const ByteArray &Data, size_t DataLen)
 {
 	init_func
 	Data.mid(DataLen).fill(0);
@@ -334,35 +329,29 @@ void ISOPad(const ByteArray &Data,DWORD DataLen)
 	exit_func
 }
 
-const ByteDynArray& ISOPad16(const ByteArray &data, ByteDynArray &resp) {
+const ByteDynArray ISOPad16(const ByteArray &data) {
 	init_func
-		resp.resize(ISOPadLen16(data.size()));
+	ByteDynArray resp(ISOPadLen16(data.size()));
 	resp.copy(data);
 	ISOPad(resp, data.size());
 	_return(resp);
 	exit_func
 }
 
-const ByteDynArray& ISOPad(const ByteArray &data,ByteDynArray &resp) {
+const ByteDynArray ISOPad(const ByteArray &data) {
 	init_func
-	resp.resize(ISOPadLen(data.size()));
+	ByteDynArray resp(ISOPadLen(data.size()));
 	resp.copy(data);
 	ISOPad(resp,data.size());
 	_return (resp);
 	exit_func
 }
 
-void randomize(ByteArray &ba) 
-{
-	for (DWORD i=0;i<ba.dwSize;i++)
-		ba.pbtData[i]=rand()%0x100;
-}
-
-DWORD ByteArrayToInt(ByteArray &ba)
+long ByteArrayToInt(ByteArray &ba)
 {
 	init_func
 	long val=0;
-	for (DWORD i=0;i<ba.size();i++) {
+	for (size_t i = 0; i<ba.size(); i++) {
 		val<<=8;
 		val|=ba[i];
 	}
@@ -371,22 +360,10 @@ DWORD ByteArrayToInt(ByteArray &ba)
 }
 
 
-static char szWinErrBuffer[300];
-char * WinErr(HRESULT err) {
-	FormatMessage(FORMAT_MESSAGE_IGNORE_INSERTS|FORMAT_MESSAGE_FROM_SYSTEM,NULL,err,MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),szWinErrBuffer,300,NULL);
-	return(szWinErrBuffer);
-}
-
-char _strErrorString[1000];
-char _strAppoErrorString[1000];
-
-char *err_string(const char *format,...) {
-	va_list params;
-	va_start (params, format);
-	vsprintf_s(_strAppoErrorString,1000, format, params);
-	va_end(params);
-	strcpy_s(_strErrorString,_strAppoErrorString);
-	return(_strErrorString);
+std::string WinErr(HRESULT err) {
+	char szWinErrBuffer[300];
+	FormatMessage(FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_SYSTEM, NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), szWinErrBuffer, 300, NULL);
+	return std::string(szWinErrBuffer);
 }
 
 char *  CardErr(DWORD dwSW) {
@@ -473,12 +450,12 @@ char *SystemErr(DWORD dwExcept){
 	}
 }
 
-ByteDynArray& setASN1Tag(ByteDynArray& result,DWORD tag,ByteArray &content) {
-	content.setASN1Tag(tag,result);
+ByteDynArray ASN1Tag(DWORD tag,ByteArray &content) {
+	ByteDynArray result = content.getASN1Tag(tag);
 	return result;
 }
 
-int ASN1TLength(DWORD tag) {
+size_t ASN1TLength(unsigned int tag) {
 	int tLen=0;
 	while (tag!=0) {
 		tLen++;
@@ -486,10 +463,10 @@ int ASN1TLength(DWORD tag) {
 	}
 	return tLen;
 }
-void putASN1Tag(DWORD tag,ByteArray &data) {
+void putASN1Tag(unsigned int tag, ByteArray &data) {
 	int tPos=0;
 	while (tag!=0) {
-		BYTE b=tag >> 24;
+		uint8_t b = tag >> 24;
 		if (b!=0) {
 			data[tPos]=b;
 			tPos++;
@@ -498,7 +475,7 @@ void putASN1Tag(DWORD tag,ByteArray &data) {
 	}
 }
 
-int ASN1LLength(LONG len) {
+size_t ASN1LLength(size_t len) {
 	if (len<0x80)
 		return 1;
 	else {
@@ -512,35 +489,35 @@ int ASN1LLength(LONG len) {
 		else if (len<=0xffffffff)
 			return 5;
 	}
-	throw CStringException("Lunghezza ASN1 non valida");
+	throw std::runtime_error("Lunghezza ASN1 non valida");
 }
 
-void putASN1Length(LONG len,ByteArray &data) {
-	if (len<0x80) {
-		data[0]=(BYTE)len;
+void putASN1Length(size_t len, ByteArray &data) {
+	if (len < 0x80) {
+		data[0] = (uint8_t)len;
 	}
 	else {
-		if (len<=0xff) {
-			data[0]=(0x81);
-			data[1] = (BYTE)(len);
+		if (len <= 0xff) {
+			data[0] = (0x81);
+			data[1] = (uint8_t)(len);
 		}
-		else if (len<=0xffff) {
-			data[0]=(0x82);
-			data[1] = (BYTE)(len >> 8);
-			data[2]=(len & 0xff);
+		else if (len <= 0xffff) {
+			data[0] = (0x82);
+			data[1] = (uint8_t)(len >> 8);
+			data[2] = (len & 0xff);
 		}
-		else if (len<=0xffffff) {
-			data[0]=(0x83);
-			data[1] = (BYTE)(len >> 16);
-			data[2]=((len >> 8) & 0xff);
-			data[3]=(len & 0xff);
+		else if (len <= 0xffffff) {
+			data[0] = (0x83);
+			data[1] = (uint8_t)(len >> 16);
+			data[2] = ((len >> 8) & 0xff);
+			data[3] = (len & 0xff);
 		}
-		else if (len<=0xffffffff) {
-			data[0]=(0x84);
-			data[1]=(len >> 24);
-			data[2]=((len >> 16) & 0xff);
-			data[3]=((len >> 8) & 0xff);
-			data[4]=(len & 0xff);
+		else if (len <= 0xffffffff) {
+			data[0] = (0x84);
+			data[1] = (uint8_t)(len >> 24);
+			data[2] = ((len >> 16) & 0xff);
+			data[3] = ((len >> 8) & 0xff);
+			data[4] = (len & 0xff);
 		}
 	}
 }
@@ -549,7 +526,7 @@ BYTE checkdigit(ByteArray &data) {
 	int weight[3] = {7,3,1};
 	int tot=0;
 	int curval=0;
-	for(DWORD i = 0;i<data.size();i++) {
+	for (size_t i = 0; i<data.size(); i++) {
 		char ch=toupper(data[i]);
 		if (ch >= 'A' && ch <= 'Z')
             curval = ch - 'A' + 10;
@@ -560,7 +537,7 @@ BYTE checkdigit(ByteArray &data) {
 				if (ch == '<')
                     curval = 0;
                 else
-                    throw CStringException("errore nel calcolo della check digit");
+					throw std::runtime_error("errore nel calcolo della check digit");
 			}
 		}
         tot += curval * weight[i % 3];
@@ -578,4 +555,16 @@ void ICAODate(SYSTEMTIME &time,ByteDynArray &result) {
 
 	result[4]=(time.wDay % 100) /10;
 	result[5]=time.wDay % 10;
+}
+
+
+std::string stdPrintf(const char *format, ...) {
+	std::string result;
+	va_list args;
+	va_start(args, format);
+	int size = _vscprintf(format, args) + 1;
+	result.resize(size);
+	vsprintf_s(&result[0], size, format, args);
+	va_end(args);
+	return result;
 }

--- a/CSP/Util/util.h
+++ b/CSP/Util/util.h
@@ -238,47 +238,42 @@ extern DWORD ERR_OBJECT_HASNT_ATTRIBUTE;
 		}
 
 
-#define VarToByteArray(a) (ByteArray((BYTE*)&(a),sizeof(a)))
-#define VarToByteDynArray(a) (ByteDynArray((BYTE*)&(a),sizeof(a)))
-#define ByteArrayToVar(a,b) (*(b*)(a).lock(sizeof(b)))
 
-void randomize(ByteArray &ba);
-
-BYTE hex2byte(char h);
+uint8_t hex2byte(char h);
 void readHexData(const char *data,ByteDynArray &ba);
-std::string HexByte(BYTE data, bool uppercase = true);
+std::string HexByte(uint8_t data, bool uppercase = true);
 std::string &dumpHexData(ByteArray &data, std::string &dump);
 std::string &dumpHexData(ByteArray &data, std::string &dump, bool withSpace, bool uppercase = true);
 std::string &dumpHexDataLowerCase(ByteArray &data, std::string &dump);
 
- void PutPaddingBT0(ByteArray &ba,DWORD dwLen);
- void PutPaddingBT1(ByteArray &ba,DWORD dwLen);
- void PutPaddingBT2(ByteArray &ba,DWORD dwLen);
- DWORD RemovePaddingBT1(ByteArray &paddedData);
- DWORD RemovePaddingBT2(ByteArray &paddedData);
- DWORD RemoveISOPad(ByteArray &paddedData);
+void PutPaddingBT0(ByteArray &ba, size_t dwLen);
+void PutPaddingBT1(ByteArray &ba, size_t dwLen);
+void PutPaddingBT2(ByteArray &ba, size_t dwLen);
+size_t RemovePaddingBT1(ByteArray &paddedData);
+size_t RemovePaddingBT2(ByteArray &paddedData);
+size_t RemoveISOPad(ByteArray &paddedData);
 
- DWORD RemoveSha1(ByteArray &paddedData);
- DWORD RemoveSha256(ByteArray &paddedData);
+size_t RemoveSha1(ByteArray &paddedData);
+size_t RemoveSha256(ByteArray &paddedData);
 
- DWORD ANSIPadLen(DWORD Len);
- void ANSIPad(ByteArray &Data,DWORD DataLen);
- DWORD ISOPadLen(DWORD Len);
- void ISOPad(const ByteArray &Data,DWORD DataLen);
- DWORD ByteArrayToInt(ByteArray &ba);
-const ByteDynArray& ISOPad(const ByteArray &data,ByteDynArray &resp);
-const ByteDynArray& ISOPad16(const ByteArray &data, ByteDynArray &resp);
+size_t ANSIPadLen(size_t Len);
+void ANSIPad(ByteArray &Data, size_t DataLen);
+size_t ISOPadLen(size_t Len);
+void ISOPad(const ByteArray &Data, size_t DataLen);
+long ByteArrayToInt(ByteArray &ba);
+const ByteDynArray ISOPad(const ByteArray &data);
+const ByteDynArray ISOPad16(const ByteArray &data);
 
- char * WinErr(HRESULT ris);
+ std::string WinErr(HRESULT ris);
  char * CardErr(DWORD dwSW);
  char * SystemErr(DWORD dwExcept);
- char * err_string(const char *format,...);
-
+ 
  void exceptionTranslator( unsigned int u, _EXCEPTION_POINTERS* pExp );
  void StackWalkThread(std::string &stack);
 
  void Debug(ByteArray ba);
- ByteDynArray& setASN1Tag(ByteDynArray& result,DWORD tag,ByteArray &content);
- BYTE checkdigit(ByteArray &data);
+ ByteDynArray ASN1Tag(DWORD tag,ByteArray &content);
+ uint8_t checkdigit(ByteArray &data);
  void ICAODate(SYSTEMTIME &time,ByteDynArray &result);
 
+ std::string stdPrintf(const char *format, ...);

--- a/CacheLib/CacheLib.cpp
+++ b/CacheLib/CacheLib.cpp
@@ -32,7 +32,7 @@ bool CacheExists(const char *PAN) {
 	return (PathFileExists(szPath)!=FALSE);
 }
 
-void CacheGetCertificate(const char *PAN, std::vector<BYTE>&certificate)
+void CacheGetCertificate(const char *PAN, std::vector<uint8_t>&certificate)
 {
 	if (PAN == nullptr)
 		throw CStringException("Il PAN è necessario");
@@ -44,12 +44,12 @@ void CacheGetCertificate(const char *PAN, std::vector<BYTE>&certificate)
 
 		ByteDynArray data,Cert;
 		data.load(szPath);
-		BYTE *ptr = data.lock();
+		uint8_t *ptr = data.data();
 		int len = *(int*)ptr; ptr += sizeof(int);
 		// salto il PIN
 		ptr += len;
 		len = *(int*)ptr; ptr += sizeof(int);
-		Cert.resize(len); Cert.copy(ptr, len);
+		Cert.resize(len); Cert.copy(ByteArray(ptr, len));
 
 		certificate.resize(Cert.size());
 		ByteArray(certificate.data(), certificate.size()).copy(Cert);
@@ -58,7 +58,7 @@ void CacheGetCertificate(const char *PAN, std::vector<BYTE>&certificate)
 		throw CStringException("CIE non abilitata");
 }
 
-void CacheGetPIN(const char *PAN, std::vector<BYTE>&PIN) {
+void CacheGetPIN(const char *PAN, std::vector<uint8_t>&PIN) {
 	if (PAN == nullptr)
 		throw CStringException("Il PAN è necessario");
 
@@ -68,9 +68,9 @@ void CacheGetPIN(const char *PAN, std::vector<BYTE>&PIN) {
 	if (PathFileExists(szPath)) {
 		ByteDynArray data, ClearPIN;
 		data.load(szPath);
-		BYTE *ptr = data.lock();
+		uint8_t *ptr = data.data();
 		int len = *(int*)ptr; ptr += sizeof(int);
-		ClearPIN.resize(len); ClearPIN.copy(ptr, len);
+		ClearPIN.resize(len); ClearPIN.copy(ByteArray(ptr, len));
 
 		PIN.resize(ClearPIN.size());
 		ByteArray(PIN.data(), PIN.size()).copy(ClearPIN);
@@ -83,7 +83,7 @@ void CacheGetPIN(const char *PAN, std::vector<BYTE>&PIN) {
 
 
 
-void CacheSetData(const char *PAN, BYTE *certificate, int certificateSize, BYTE *FirstPIN, int FirstPINSize) {
+void CacheSetData(const char *PAN, uint8_t *certificate, int certificateSize, uint8_t *FirstPIN, int FirstPINSize) {
 	if (PAN == nullptr)
 		throw CStringException("Il PAN è necessario");
 
@@ -103,13 +103,13 @@ void CacheSetData(const char *PAN, BYTE *certificate, int certificateSize, BYTE 
 	if (f == nullptr)
 		throw CStringException("Errore in scrittura file cache del certificato");
 
-	int len = baFirstPIN.size();
+	size_t len = baFirstPIN.size();
 	fwrite(&len, sizeof(len), 1, f);
-	fwrite(baFirstPIN.lock(), len, 1, f);
+	fwrite(baFirstPIN.data(), len, 1, f);
 
 	len = baCertificate.size();
 	fwrite(&len, sizeof(len), 1, f);
-	fwrite(baCertificate.lock(), len, 1, f);
+	fwrite(baCertificate.data(), len, 1, f);
 
 	fclose(f);
 }

--- a/CacheLib/CacheLib.h
+++ b/CacheLib/CacheLib.h
@@ -1,7 +1,8 @@
 ﻿#pragma once
 #include <vector>
+#include <stdint.h>
 
 bool CacheExists(const char *PAN);
-void CacheGetCertificate(const char *PAN, std::vector<BYTE>&certificate);
-void CacheGetPIN(const char *PAN, std::vector<BYTE>&PIN);
-void CacheSetData(const char *PAN, BYTE *certificate, int certificateSize, BYTE *FirstPIN, int FirstPINSize);
+void CacheGetCertificate(const char *PAN, std::vector<uint8_t>&certificate);
+void CacheGetPIN(const char *PAN, std::vector<uint8_t>&PIN);
+void CacheSetData(const char *PAN, uint8_t *certificate, int certificateSize, uint8_t *FirstPIN, int FirstPINSize);

--- a/CacheLib_keys/CacheLib.h
+++ b/CacheLib_keys/CacheLib.h
@@ -1,0 +1,8 @@
+﻿#pragma once
+#include <vector>
+
+bool CacheExists(const char *PAN);
+void CacheGetCertificate(const char *PAN, std::vector<BYTE>&certificate);
+void CacheGetPIN(const char *PAN, std::vector<BYTE>&PIN);
+void CacheSetData(const char *PAN, BYTE *certificate, int certificateSize, BYTE *FirstPIN, int FirstPINSize);
+


### PR DESCRIPTION
Another big PR.
Array<T> is gone, now ByteArray is a base class and ByteDynArray is derived.
Move semantics is defined for ByteDynArray, so some function signatures have changed to avoid useless temporary objects.
BYTE and DWORD types were replaced almost everywhere with unit8_t and unit32_t, safe for Windows API call.
Next: replace all threads and synchronization objects
