### PR TITLE
Remove CThread

### DIFF
--- a/CSP/CSP.vcxproj
+++ b/CSP/CSP.vcxproj
@@ -241,9 +241,7 @@
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="CSP\StoreProvider.cpp" />
     <ClCompile Include="Util\SyncroEvent.cpp" />
-    <ClCompile Include="Util\SyncroMutex.cpp" />
     <ClCompile Include="UI\SystemTray.cpp" />
-    <ClCompile Include="Util\Thread.cpp" />
     <ClCompile Include="Util\TLV.cpp" />
     <ClCompile Include="PCSC\Token.cpp" />
     <ClCompile Include="Util\util.cpp" />
@@ -290,9 +288,7 @@
     <ClInclude Include="UI/safeDesktop.h" />
     <ClInclude Include="StdAfx.h" />
     <ClInclude Include="Util\SyncroEvent.h" />
-    <ClInclude Include="Util\SyncroMutex.h" />
     <ClInclude Include="UI\SystemTray.h" />
-    <ClInclude Include="Util\Thread.h" />
     <ClInclude Include="Util\TLV.h" />
     <ClInclude Include="PCSC\Token.h" />
     <ClInclude Include="Util\util.h" />

--- a/CSP/CSP.vcxproj.filters
+++ b/CSP/CSP.vcxproj.filters
@@ -132,12 +132,6 @@
     <ClCompile Include="Util\SyncroEvent.cpp">
       <Filter>Source Files\Util</Filter>
     </ClCompile>
-    <ClCompile Include="Util\SyncroMutex.cpp">
-      <Filter>Source Files\Util</Filter>
-    </ClCompile>
-    <ClCompile Include="Util\Thread.cpp">
-      <Filter>Source Files\Util</Filter>
-    </ClCompile>
     <ClCompile Include="Util\util.cpp">
       <Filter>Source Files\Util</Filter>
     </ClCompile>
@@ -252,12 +246,6 @@
       <Filter>Header Files\Util</Filter>
     </ClInclude>
     <ClInclude Include="Util\SyncroEvent.h">
-      <Filter>Header Files\Util</Filter>
-    </ClInclude>
-    <ClInclude Include="Util\SyncroMutex.h">
-      <Filter>Header Files\Util</Filter>
-    </ClInclude>
-    <ClInclude Include="Util\Thread.h">
       <Filter>Header Files\Util</Filter>
     </ClInclude>
     <ClInclude Include="Util\util.h">

--- a/CSP/CSP/abilitaCIE.cpp
+++ b/CSP/CSP/abilitaCIE.cpp
@@ -140,18 +140,17 @@ DWORD WINAPI _abilitaCIE(
 							if (IdServizi != ByteArray((uint8_t*)PAN, strnlen(PAN, 20)))
 								continue;
 
-							DWORD id;
+							//DWORD id;
 							HWND progWin = nullptr;
 							struct threadData th;
 							th.progWin = &progWin;
 							th.hDesk = (HDESK)(*desk);
-							CreateThread(nullptr, 0, [](LPVOID lpThreadParameter) -> DWORD {
-								struct threadData *th = (struct threadData*)lpThreadParameter;
-								SetThreadDesktop(th->hDesk);
-								CVerifica ver(th->progWin);
+							std::thread([&th]() -> DWORD {
+								SetThreadDesktop(th.hDesk);
+								CVerifica ver(th.progWin);
 								ver.DoModal();
 								return 0;
-							}, &th, 0, &id);
+							}).detach();
 
 							ias->Callback = [](int prog, char *desc, void *data) {
 								HWND progWin = *(HWND*)data;
@@ -285,15 +284,9 @@ extern "C" int CALLBACK AbilitaCIE(
 		ODS("Already running AbilitaCIE");
 		return 0;
 	}
-	DWORD id;
-	HANDLE thread = CreateThread(nullptr, 0, _abilitaCIE, lpCmdLine, 0, &id);
-	if (thread == NULL) {
-		ODS("Errore in creazione thread su AbilitaCIE");
-		return 0;
-	}
-
-	WaitForSingleObject(thread, INFINITE);
-	CloseHandle(thread);
+	//std::thread thread(_abilitaCIE, lpCmdLine);
+	//thread.join();
+	_abilitaCIE(lpCmdLine);
 	ODS("End AbilitaCIE");
 	return 0;
 }

--- a/CSP/CSP/cambioPIN.cpp
+++ b/CSP/CSP/cambioPIN.cpp
@@ -20,8 +20,7 @@ extern "C" DWORD WINAPI CardAcquireContext(IN PCARD_DATA pCardData, __in DWORD d
 #pragma comment(linker, "/export:CambioPIN=_CambioPIN@16")
 #endif
 
-DWORD WINAPI _cambioPIN(
-	LPVOID lpThreadParameter) {
+DWORD WINAPI _cambioPIN() {
 	init_main_func
 
 	SCARDCONTEXT hSC;
@@ -237,15 +236,8 @@ extern "C" int CALLBACK CambioPIN(
 
 	ODS("Start CambioPIN");
 
-	DWORD id;
-	HANDLE thread = CreateThread(nullptr, 0, _cambioPIN, lpCmdLine, 0, &id);
-	if (thread == NULL) {
-		ODS("Errore in creazione thread su CambioPIN");
-		return 0;
-	}
+	_cambioPIN();
 
-	WaitForSingleObject(thread, INFINITE);
-	CloseHandle(thread);
 	ODS("End CambioPIN");
 	return 0;
 }

--- a/CSP/PCSC/PCSC.cpp
+++ b/CSP/PCSC/PCSC.cpp
@@ -97,7 +97,7 @@ readerMonitor::readerMonitor(void(*eventHandler)(std::string &reader, bool inser
 		auto loadReaderList = [&]() -> void {
 			char *readers = nullptr;
 			DWORD len = SCARD_AUTOALLOCATE;
-			if (SCardListReaders(rm->hContext, nullptr, (char*)&readers, &len) != SCARD_S_SUCCESS || readers==nullptr) {
+			if (SCardListReaders(rm->hContext, nullptr, (char*)&readers, &len) != SCARD_S_SUCCESS || readers == nullptr) {
 				throw CStringException("Nessun lettore installato");
 			}
 			char *curReader = readers;
@@ -112,7 +112,7 @@ readerMonitor::readerMonitor(void(*eventHandler)(std::string &reader, bool inser
 			}
 			auto &PnP = states[(DWORD)readerList.size()];
 			PnP.szReader = "\\\\?PnP?\\Notification";
-			PnP.pvUserData = (void*)PnP.szReader;		
+			PnP.pvUserData = (void*)PnP.szReader;
 
 			SCardGetStatusChange(rm->hContext, 0, states.data(), states.size());
 			for (DWORD i = 0; i < states.size(); i++)

--- a/CSP/PKCS11/Slot.h
+++ b/CSP/PKCS11/Slot.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <vector>
 #include <memory>
+#include <thread>
 
 namespace p11 {
 
@@ -108,10 +109,10 @@ public:
 								// i dati specifici del template della carta,
 								// gestiti dalla DLL manager
 
-	static CThread Thread;		// thread monitor degli eventi
+	static std::thread Thread;		// thread monitor degli eventi
 	static CCardContext *ThreadContext; // context del monitor degli eventi
 
-	CSyncroMutex slotMutex;		// mutex per il lock alla carta
+	//CSyncroMutex slotMutex;		// mutex per il lock alla carta
 	SlotEvent lastEvent;
 
 	CK_RV GetInfo(CK_SLOT_INFO_PTR pInfo);

--- a/CSP/PKCS11/session.cpp
+++ b/CSP/PKCS11/session.cpp
@@ -7,7 +7,6 @@
 
 static char *szCompiledFile = __FILE__;
 
-
 namespace {
 
 	template<class T>
@@ -94,12 +93,12 @@ namespace p11 {
 			P11ER_CALL(GetNewSessionID(pSession->hSessionHandle),
 			ERR_GET_NEW_SESSION)
 
-			g_mSessions.insert(std::make_pair(pSession->hSessionHandle, std::move(pSession)));
 		hSession = pSession->hSessionHandle;
 		P11ER_CALL(pSession->pSlot->pTemplate->FunctionList.templateInitSession(pSession->pSlot->pTemplateData),
 			ERR_INIT_SESSION)
 
 			pSession->pSlot->dwSessionCount++;
+		g_mSessions.insert(std::make_pair(pSession->hSessionHandle, std::move(pSession)));
 
 		_return(OK)
 			exit_func
@@ -330,7 +329,7 @@ namespace p11 {
 		init_func
 			for (unsigned int i = 0; i<ulCount; i++) {
 				if (pTemplate[i].type == type) {
-					val= ByteArray((uint8_t*)pTemplate[i].pValue, pTemplate[i].ulValueLen);
+					val = ByteArray((uint8_t*)pTemplate[i].pValue, pTemplate[i].ulValueLen);
 					_return(OK)
 				}
 			}
@@ -526,18 +525,18 @@ namespace p11 {
 	{
 		init_func
 
-		CK_ULONG ulReqLen = 0;
+			CK_ULONG ulReqLen = 0;
 		P11ER_CALL(pDigestMechanism->DigestLength(&ulReqLen),
 			ERR_CANT_GET_MECHANISM_LENGTH)
 
-		if (!Digest.isNull() && Digest.size() < ulReqLen)
-			_return(CKR_BUFFER_TOO_SMALL)
+			if (!Digest.isNull() && Digest.size() < ulReqLen)
+				_return(CKR_BUFFER_TOO_SMALL)
 
-		Digest = Digest.left(ulReqLen);
+				Digest = Digest.left(ulReqLen);
 		if (Digest.isNull())
 			_return(OK)
 
-		CK_RV result = DigestUpdate(Data);
+			CK_RV result = DigestUpdate(Data);
 		if (result != OK)
 			_return(result)
 

--- a/CSP/Util/SyncroEvent.cpp
+++ b/CSP/Util/SyncroEvent.cpp
@@ -1,111 +1,20 @@
 #include "../stdAfx.h"
 #include "syncroEvent.h"
 
-static char *szCompiledFile=__FILE__;
-
-CSyncroEvent::CSyncroEvent(void)
+void auto_reset_event::set()
 {
-	init_func_internal
-#ifdef WIN32
-	hEvent=CreateEvent(NULL,FALSE,FALSE,NULL);
-	if (hEvent==NULL) {
-		throw CStringException("Impossibile create l'evento");
+	{
+		std::unique_lock<std::mutex> lock(m_);
+		signaled_ = true;
 	}
-#endif
-	exit_func_internal
+
+	cv_.notify_one();
 }
 
-CSyncroEvent::CSyncroEvent(const char *szName)
+void auto_reset_event::wait()
 {
-	init_func_internal
-#ifdef WIN32
-	hEvent=OpenEvent(SYNCHRONIZE,FALSE,szName);
-	if (hEvent==NULL) {
-		HRESULT r=GetLastError();
-		if (r==ERROR_FILE_NOT_FOUND) {
-			SECURITY_ATTRIBUTES attr;
-			SECURITY_DESCRIPTOR secDesc;
-			DWORD dwACL=sizeof(ACL)+sizeof(ACCESS_ALLOWED_ACE)+sizeof(SID);
-			ByteDynArray pbtACL(dwACL);
-			PACL pACL=(PACL)pbtACL.data();
-
-			InitializeAcl(pACL,dwACL,ACL_REVISION);
-			PSID pSid;
-			SID_IDENTIFIER_AUTHORITY worldSidAuth=SECURITY_WORLD_SID_AUTHORITY;
-			AllocateAndInitializeSid(&worldSidAuth,1,SECURITY_WORLD_RID,0,0,0,0,0,0,0,&pSid);
-
-			AddAccessAllowedAceEx(pACL, ACL_REVISION, INHERITED_ACE,SYNCHRONIZE, pSid);
-
-			InitializeSecurityDescriptor(&secDesc,SECURITY_DESCRIPTOR_REVISION);
-			SetSecurityDescriptorDacl(&secDesc,TRUE,pACL,FALSE);
-
-			attr.bInheritHandle=FALSE;
-			attr.lpSecurityDescriptor=&secDesc;
-
-			hEvent=CreateEvent(&attr,FALSE,FALSE,szName);
-			if (hEvent==NULL) {
-				throw CStringException("Impossibile create l'evento");
-			}
-			FreeSid(pSid);
-		}
-		else {
-			throw CStringException("Impossibile create l'evento");
-		}
-	}
-#endif
-	exit_func_internal
-}
-
-CSyncroEvent::~CSyncroEvent(void)
-{
-	init_func_internal
-#ifdef WIN32
-	CloseHandle(hEvent);
-#endif
-	exit_func_internal
-}
-
-void CSyncroEvent::Wait()
-{
-	init_func_internal
-#ifdef WIN32
-	HRESULT hr;
-	if ((hr=WaitForSingleObject(hEvent,INFINITE))!=S_OK) {
-		throw CWinException(hr);
-	}
-#endif
-	exit_func_internal
-}
-
-void CSyncroEvent::Signal()
-{
-	init_func_internal
-#ifdef WIN32
-	if (!SetEvent(hEvent)) {
-		throw CWinException();
-	}
-#endif
-	exit_func_internal
-}
-
-CSyncroSignaler::CSyncroSignaler(CSyncroEvent &event)
-{
-	init_func_internal
-	pEvent=&event;
-	exit_func_internal
-}
-
-void CSyncroSignaler::detach()
-{
-	init_func_internal
-	pEvent=NULL;
-	exit_func_internal
-}
-
-CSyncroSignaler::~CSyncroSignaler()
-{
-	init_func_internal
-	if (pEvent)
-		pEvent->Signal();
-	exit_func_internal
+	std::unique_lock<std::mutex> lock(m_);
+	while (!signaled_)
+		cv_.wait(lock);
+	signaled_ = false;
 }

--- a/CSP/Util/SyncroEvent.h
+++ b/CSP/Util/SyncroEvent.h
@@ -1,25 +1,22 @@
 #pragma once
 
-class CSyncroEvent
+#include <mutex>
+#include <condition_variable>
+
+
+class auto_reset_event
 {
-#ifdef WIN32
-	HANDLE hEvent;
-#endif
 public:
-	CSyncroEvent(void);
-	CSyncroEvent(const char *name);
-	~CSyncroEvent(void);
+	auto_reset_event(bool signaled = false)
+		: signaled_(signaled)
+	{
+	}
 
-	void Signal();
-	void Wait();
-};
+	void set();
+	void wait();
 
-class CSyncroSignaler
-{
-	CSyncroEvent *pEvent;
-public:
-	CSyncroSignaler(CSyncroEvent &event);
-	~CSyncroSignaler();
-
-	void detach();
+private:
+	std::mutex m_;
+	std::condition_variable cv_;
+	bool signaled_;
 };

--- a/CSP/Util/SyncroMutex.h
+++ b/CSP/Util/SyncroMutex.h
@@ -6,8 +6,9 @@ class CSyncroMutex
 {
 	HANDLE hMutex;
 public:
-	CSyncroMutex(void);
 	void Create(void);
+
+	CSyncroMutex(void);
 	void Create(const char *name);
 	~CSyncroMutex(void);
 

--- a/CSP/Util/Thread.h
+++ b/CSP/Util/Thread.h
@@ -5,7 +5,7 @@
 
 class CThread
 {
-public:
+//public:
 	CThread(void);
 	~CThread(void);
 #ifdef WIN32

--- a/CSP/Util/log.cpp
+++ b/CSP/Util/log.cpp
@@ -9,6 +9,7 @@
 #include "UtilException.h"
 #include "thread.h"
 #include "IniSettings.h"
+#include <thread>
 
 
 static char *szCompiledFile=__FILE__;
@@ -229,7 +230,7 @@ DWORD CLog::write(const char *format,...) {
 		sprintf_s(pbtDate,sizeof(pbtDate),"%05u:[%02d:%02d:%02d.%03d]", *Num, stTime.wHour, stTime.wMinute, stTime.wSecond, stTime.wMilliseconds);	
 	 
 		// se siamo in LM_thread devo scrivere il thread nel nome del file
-		DWORD dwThreadID=CThread::getID();
+		auto dwThreadID = std::this_thread::get_id().hash();
 		if (LogMode == LM_Thread || LogMode == LM_Module_Thread) {
 			std::stringstream th;
 			th << std::setiosflags(std::ios::hex | std::ios::uppercase);
@@ -292,7 +293,7 @@ void CLog::writePure(const char *format,...) {
 		}
 
 		// se siamo in LM_thread devo scrivere il thread nel nome del file
-		DWORD dwThreadID=CThread::getID();
+		auto dwThreadID = std::this_thread::get_id().hash();
 		if (LogMode == LM_Thread || LogMode == LM_Module_Thread) {
 			std::stringstream th;
 			th << std::setiosflags(std::ios::hex | std::ios::uppercase);
@@ -339,7 +340,7 @@ void CLog::writeBinData(BYTE *data, size_t datalen) {
 	char pbtDate[0x800]={NULL};
 
 	// se siamo in LM_thread devo scrivere il thread nel nome del file
-	DWORD dwThreadID=CThread::getID();
+	auto dwThreadID = std::this_thread::get_id().hash();
 	if (LogMode == LM_Thread || LogMode == LM_Module_Thread) {
 		std::stringstream th;
 		th << std::setiosflags(std::ios::hex | std::ios::uppercase);

--- a/CSP/Util/log.cpp
+++ b/CSP/Util/log.cpp
@@ -52,7 +52,7 @@ void initLog(const char *iniFile,const char *version) {
 	OutputDebugString(iniFile);
 	OutputDebugString("\n");
 
-	LogMode = (logMode)(IniSettingsInt("Log", "LogMode", (int)LM_Single, "Modalit‡ di Log. Valori possibili:\n"
+	LogMode = (logMode)(IniSettingsInt("Log", "LogMode", (int)LM_Single, "Modalit√† di Log. Valori possibili:\n"
 		"0 ;LM_Single,	// un solo file\n"
 		"1 ;LM_Module,	// un file per modulo\n"
 		"2 ;LM_Thread,	// un file per thread\n"
@@ -66,7 +66,7 @@ void initLog(const char *iniFile,const char *version) {
 
 	FunctionLog = (IniSettingsBool("Log", "FunctionLog", false, "Abilitazione log delle chiamate a funzione")).GetValue((char*)iniFile);
 
-	GlobalDepth = (IniSettingsInt("Log", "FunctionDepth", 10, "Definisce la profondit‡ massima di log delle funzioni\n")).GetValue((char*)iniFile);
+	GlobalDepth = (IniSettingsInt("Log", "FunctionDepth", 10, "Definisce la profondit√† massima di log delle funzioni\n")).GetValue((char*)iniFile);
 
 	GlobalParam = (IniSettingsBool("Log", "ParamLog", false, "Abilitazione log dei parametri di input delle funzioni")).GetValue((char*)iniFile);
 
@@ -144,29 +144,29 @@ void CLog::initParam(CLog &log) {
 		}
 		case (LM_Module): {
 			th << std::setw(4) << stTime.wYear << "-" << std::setw(2) << stTime.wMonth << "-" << stTime.wDay << "_" << logFileName << ".log";
-			// log per modulo: il nome del file Ë yyyy-mm-gg_name.log, senza alcun path assegnato
+			// log per modulo: il nome del file √® yyyy-mm-gg_name.log, senza alcun path assegnato
 			break;
 		}
 		case (LM_Thread): {
 			th << std::setw(4) << stTime.wYear << "-" << std::setw(2) << stTime.wMonth << "-" << stTime.wDay << "_00000000.log";
-			// log per thread: il nome del file Ë yyyy-mm-gg_tttttttt.log, senza alcun path assegnato
+			// log per thread: il nome del file √® yyyy-mm-gg_tttttttt.log, senza alcun path assegnato
 			break;
 		}
 		case (LM_Module_Thread): {
 			th << std::setw(4) << stTime.wYear << "-" << std::setw(2) << stTime.wMonth << "-" << stTime.wDay << "_" << logFileName << "_00000000.log";
-			// log per modulo e per thread: il nome del file Ë yyyy-mm-gg_name_tttttttt.log, senza alcun path assegnato
+			// log per modulo e per thread: il nome del file √® yyyy-mm-gg_name_tttttttt.log, senza alcun path assegnato
 			break;
 		}
 	}
 	logPath = th.str();
 
 	if ((LogMode==LM_Module || LogMode==LM_Module_Thread) && log.logDir.length()!=0) {
-		// se c'Ë un path specifico lo metto lÏ
+		// se c'√® un path specifico lo metto l√¨
 		std::string path = logPath;
 		logPath=log.logDir.append("\\").append(path);
 	}
 	else if (!logDirGlobal.empty()) {
-		// se c'Ë un path globale lo metto lÏ
+		// se c'√® un path globale lo metto l√¨
 		std::string path=logPath;
 		logPath = logDirGlobal.append("\\").append(path);
 	}
@@ -184,7 +184,7 @@ void CLog::initModule(const char *name, const char *version) {
 	logVersion=version;
 
 	if (!InitLog)
-	// verr‡ inizializzato dopo, quando chiamo logInit
+	// verr√† inizializzato dopo, quando chiamo logInit
 		logToInit.push_back(this);
 	else {
 		// vediamo se ce l'ho...
@@ -230,7 +230,8 @@ DWORD CLog::write(const char *format,...) {
 		sprintf_s(pbtDate,sizeof(pbtDate),"%05u:[%02d:%02d:%02d.%03d]", *Num, stTime.wHour, stTime.wMinute, stTime.wSecond, stTime.wMilliseconds);	
 	 
 		// se siamo in LM_thread devo scrivere il thread nel nome del file
-		auto dwThreadID = std::this_thread::get_id().hash();
+		std::hash<std::thread::id> hasher;
+		auto dwThreadID = hasher(std::this_thread::get_id);
 		if (LogMode == LM_Thread || LogMode == LM_Module_Thread) {
 			std::stringstream th;
 			th << std::setiosflags(std::ios::hex | std::ios::uppercase);
@@ -293,7 +294,8 @@ void CLog::writePure(const char *format,...) {
 		}
 
 		// se siamo in LM_thread devo scrivere il thread nel nome del file
-		auto dwThreadID = std::this_thread::get_id().hash();
+		std::hash<std::thread::id> hasher;
+		auto dwThreadID = hasher(std::this_thread::get_id);
 		if (LogMode == LM_Thread || LogMode == LM_Module_Thread) {
 			std::stringstream th;
 			th << std::setiosflags(std::ios::hex | std::ios::uppercase);
@@ -340,7 +342,8 @@ void CLog::writeBinData(BYTE *data, size_t datalen) {
 	char pbtDate[0x800]={NULL};
 
 	// se siamo in LM_thread devo scrivere il thread nel nome del file
-	auto dwThreadID = std::this_thread::get_id().hash();
+	std::hash<std::thread::id> hasher;
+	auto dwThreadID = hasher(std::this_thread::get_id);
 	if (LogMode == LM_Thread || LogMode == LM_Module_Thread) {
 		std::stringstream th;
 		th << std::setiosflags(std::ios::hex | std::ios::uppercase);

--- a/CSP/Util/log.cpp
+++ b/CSP/Util/log.cpp
@@ -231,7 +231,7 @@ DWORD CLog::write(const char *format,...) {
 	 
 		// se siamo in LM_thread devo scrivere il thread nel nome del file
 		std::hash<std::thread::id> hasher;
-		auto dwThreadID = hasher(std::this_thread::get_id);
+		auto dwThreadID = hasher(std::this_thread::get_id());
 		if (LogMode == LM_Thread || LogMode == LM_Module_Thread) {
 			std::stringstream th;
 			th << std::setiosflags(std::ios::hex | std::ios::uppercase);
@@ -295,7 +295,7 @@ void CLog::writePure(const char *format,...) {
 
 		// se siamo in LM_thread devo scrivere il thread nel nome del file
 		std::hash<std::thread::id> hasher;
-		auto dwThreadID = hasher(std::this_thread::get_id);
+		auto dwThreadID = hasher(std::this_thread::get_id());
 		if (LogMode == LM_Thread || LogMode == LM_Module_Thread) {
 			std::stringstream th;
 			th << std::setiosflags(std::ios::hex | std::ios::uppercase);
@@ -343,7 +343,7 @@ void CLog::writeBinData(BYTE *data, size_t datalen) {
 
 	// se siamo in LM_thread devo scrivere il thread nel nome del file
 	std::hash<std::thread::id> hasher;
-	auto dwThreadID = hasher(std::this_thread::get_id);
+	auto dwThreadID = hasher(std::this_thread::get_id());
 	if (LogMode == LM_Thread || LogMode == LM_Module_Thread) {
 		std::stringstream th;
 		th << std::setiosflags(std::ios::hex | std::ios::uppercase);


### PR DESCRIPTION
Windows threads were removed in favor of std::thread to simplify portability.
Synchronization primitives  were also changed, from CMutex based on windows mutex, to std::mutex and std::unique_lock.
Windows Events are not supported in Standard Library, so an auto_reset_event class was implemented using a mutex and a condition variable.

std::mutex is not usable for Inter-process synchronization, while a named windows mutex can do it. The access to PKCS11 functions was infact synchronized across process to avoid traffic on the smart card, but the same thing can be accomplished using smart card transactions wisely.
The minidriver is based on the Base Smartcard Provider that handles card transactions, but PKCS11 has no transaction support. It should be added.
